### PR TITLE
和気あいAI調整

### DIFF
--- a/app/[lang]/events/wakiaiai/_components/event-creator-card.tsx
+++ b/app/[lang]/events/wakiaiai/_components/event-creator-card.tsx
@@ -36,11 +36,13 @@ export const EventCreatorCard = (props: Props) => {
                 item_list_name: props.user.name,
               })
             }}
+            style={{ display: "block", width: "100%", height: "100%" }}
           >
             <img
               alt={props.user.name}
               src={props.user.iconImageURL}
               className="h-full rounded shadow-xl w-full"
+              style={{ height: "100%", objectFit: "contain" }}
             />
           </a>
         </div>

--- a/app/[lang]/events/wakiaiai/page.tsx
+++ b/app/[lang]/events/wakiaiai/page.tsx
@@ -1,8 +1,10 @@
 import { eventUsers } from "@/app/[lang]/events/wakiaiai/_assets/event-users"
 import { EventCreatorCard } from "@/app/[lang]/events/wakiaiai/_components/event-creator-card"
 import { EventImage } from "@/app/[lang]/events/wakiaiai/_components/event-image"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
+import { MousePointerClickIcon } from "lucide-react"
 import type { Metadata } from "next"
 
 const EventWakiaiaiPage = async () => {
@@ -47,6 +49,12 @@ const EventWakiaiaiPage = async () => {
               "東海地方で初かもしれない、生成AIを利用したイラストの展示やグッズ等の展示即売会"
             }
           </p>
+          <a href="/events/wakiaiai2" target="_blank" rel="noopener noreferrer">
+            <Button variant={"outline"} className="text-lg font-bold m-4">
+              和気あいAI2開催決定
+              <MousePointerClickIcon className="ml-2" />
+            </Button>
+          </a>
         </div>
       </div>
       <div className={cn("grid md:grid-cols-2 md:grid-flow-col gap-2")}>

--- a/app/[lang]/events/wakiaiai2/_assets/event-users.ts
+++ b/app/[lang]/events/wakiaiai2/_assets/event-users.ts
@@ -6,7 +6,7 @@ export const eventUsers: EventUser[] = [
     types: ["SHOP", "EXHIBIT"],
     message: null,
     iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiai2_kotobanoaya.jpg?alt=media&token=6e974a20-455b-4d76-9c07-5dae27aa5566",
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiai2_kotobanoaya_160.jpg?alt=media&token=e3b4a56c-23cc-4be5-93a4-2adea6e05109",
     twitterId: "ko_to_ba_no_aya",
     aipictorsId: null,
     siteURL: null,
@@ -30,7 +30,7 @@ export const eventUsers: EventUser[] = [
     types: ["SHOP"],
     message: null,
     iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2FKARA_Beee.png?alt=media&token=a287494f-9ef3-48bc-abf2-f2bf68d0e0c3",
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiaiai2_KARA_Beee_160.png?alt=media&token=15ac947e-c5ac-443a-ba35-8ebd7224185a",
     twitterId: "KARA_Beee",
     aipictorsId: null,
     siteURL: null,
@@ -42,7 +42,7 @@ export const eventUsers: EventUser[] = [
     types: ["EXHIBIT"],
     message: null,
     iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiai2_Wood_Pecker_.jpg?alt=media&token=0ad33815-a944-4fa8-b5d5-2745eb8daf09",
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiai2_Wood_Pecker_160.jpg?alt=media&token=f96c838e-85f6-4429-9be4-356327c3d584",
     twitterId: "Wood_Pecker_",
     aipictorsId: null,
     siteURL: null,
@@ -66,7 +66,7 @@ export const eventUsers: EventUser[] = [
     types: ["EXHIBIT"],
     message: null,
     iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2FaTyRPjXLGxJB9EKrqSM43CYfWFQ8is.webp?alt=media&token=e7da37fe-0a77-4b08-b48f-8fcd33d555a8",
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiaiai2_aipictors_160.png?alt=media&token=6f7a88ee-78ae-49cd-8476-940f2d2f4707",
     twitterId: "Aipictors",
     aipictorsId: null,
     siteURL: null,
@@ -78,7 +78,7 @@ export const eventUsers: EventUser[] = [
     types: ["EXHIBIT"],
     message: null,
     iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Faz0tlecX.jpg?alt=media&token=2218b7c1-70f2-487d-a9a7-4c6f5a0b4e13",
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiaiai2_prompton_160.jpg?alt=media&token=0c91c377-890f-43c1-9c93-12c8568f993e",
     twitterId: "promptonio",
     aipictorsId: null,
     siteURL: null,

--- a/app/[lang]/events/wakiaiai2/_components/event-creator-card.tsx
+++ b/app/[lang]/events/wakiaiai2/_components/event-creator-card.tsx
@@ -42,7 +42,7 @@ export const EventCreatorCard = (props: Props) => {
               alt={props.user.name}
               src={props.user.iconImageURL}
               className="h-full rounded shadow-xl w-full"
-              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              style={{ height: "100%", objectFit: "contain" }}
             />
           </a>
         </div>

--- a/app/[lang]/events/wakiaiai2/page.tsx
+++ b/app/[lang]/events/wakiaiai2/page.tsx
@@ -53,7 +53,7 @@ const EventWakiaiaiPage = async () => {
             rel="noopener noreferrer"
           >
             <Button variant={"outline"} className="text-lg font-bold m-4">
-              出展・展示参加募集中！3/20〆切
+              出展/展示参加募集3/20〆切
               <MousePointerClickIcon className="ml-2" />
             </Button>
           </a>


### PR DESCRIPTION
- 和気あいAI1のページに2のリンクを追加
- 画像を差し替え
- スタイル調整

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `/events/wakiaiai`ページに新しいボタンを追加し、`/events/wakiaiai2`へのリンクを提供。
- **スタイル**
	- イベント作成者カードのアンカーと画像要素にインラインスタイルを追加。
	- 画像ソースのスタイル属性を`objectFit: "contain"`に変更。
- **リファクター**
	- イベントユーザーのアイコン画像URLを更新し、ファイル名に`_160`を追加し、トークンを更新して一貫性とパフォーマンスの向上を図る。
- **修正**
	- ボタン内のテキストを「出展・展示参加募集中！3/20〆切」から「出展/展示参加募集3/20〆切」に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->