### PR TITLE
通知機能を追加する

### DIFF
--- a/app/[lang]/settings/notification/_components/setting-fcm-form.tsx
+++ b/app/[lang]/settings/notification/_components/setting-fcm-form.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { config } from "@/config"
+import { getMessaging, getToken } from "firebase/messaging"
+
+export function SettingFcmForm() {
+  const onClick = async () => {
+    const token = await getToken(getMessaging(), {
+      vapidKey: config.fcm.vapidKey,
+    })
+    alert(token)
+    console.log(token)
+  }
+
+  return <Button onClick={onClick}>{"FCMトークンを取得する"}</Button>
+}

--- a/app/[lang]/settings/notification/page.tsx
+++ b/app/[lang]/settings/notification/page.tsx
@@ -1,5 +1,7 @@
+import { SettingFcmForm } from "@/app/[lang]/settings/notification/_components/setting-fcm-form"
 import { SettingNotificationForm } from "@/app/[lang]/settings/notification/_components/setting-notification-form"
 import { AppPageCenter } from "@/components/app/app-page-center"
+import { Separator } from "@/components/ui/separator"
 import type { Metadata } from "next"
 
 const SettingNotificationPage = async () => {
@@ -8,6 +10,8 @@ const SettingNotificationPage = async () => {
       <div className="w-full space-y-8">
         <p className="font-bold text-2xl">{"通知・いいね"}</p>
         <SettingNotificationForm />
+        <Separator />
+        <SettingFcmForm />
       </div>
     </AppPageCenter>
   )

--- a/app/_components/context-providers.tsx
+++ b/app/_components/context-providers.tsx
@@ -9,6 +9,8 @@ import { ApolloProvider } from "@apollo/client"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { initializeAnalytics } from "firebase/analytics"
 import { getApp, getApps, initializeApp } from "firebase/app"
+import { getMessaging, onMessage } from "firebase/messaging"
+import { toast } from "sonner"
 
 type Props = {
   children: React.ReactNode
@@ -37,4 +39,15 @@ export const ContextProviders = (props: Props) => {
 if (typeof window !== "undefined" && getApps().length === 0) {
   initializeApp(config.firebaseConfig)
   initializeAnalytics(getApp())
+  try {
+    getMessaging(getApp())
+    onMessage(getMessaging(), (payload) => {
+      if (payload.notification === undefined) return
+      toast(payload.notification.title, {
+        description: payload.notification.body,
+      })
+    })
+  } catch (error) {
+    console.error(error)
+  }
 }

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,11 @@
  * 設定
  */
 export const config = {
+  fcm: {
+    get vapidKey() {
+      return "BOvVhnNNznMu2HYzfZVdJa5hQwnAQW5Prld1gboUgkRY3rO6d3oLMP3WP0bKazNWm9AVI0LBQ8L94FTbN_Y4rn4"
+    },
+  },
   /**
    * パスの仕様: 認証バッジ
    */

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,25 @@
+importScripts('https://www.gstatic.com/firebasejs/8.8.0/firebase-app.js');
+importScripts('https://www.gstatic.com/firebasejs/8.8.0/firebase-messaging.js');
+
+const firebaseConfig = {
+  apiKey: "AIzaSyC_WDct2KrvMkMjgL2hT9CHgflrCdqt8tA",
+  authDomain: "kwkjsui8ghyt93ai5feb.firebaseapp.com",
+  projectId: "kwkjsui8ghyt93ai5feb",
+  storageBucket: "kwkjsui8ghyt93ai5feb.appspot.com",
+  messagingSenderId: "698114764060",
+  appId: "1:698114764060:web:2aae9f80fee27394b49ed9",
+  measurementId: "G-CEP0HMY1WH"
+}
+
+firebase.initializeApp(firebaseConfig);
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const notificationTitle = payload.notification.title;
+  const notificationOptions = {
+    body: payload.notification.body,
+    icon: './icon.png',
+  }
+  self.registration.showNotification(notificationTitle, notificationOptions);
+})


### PR DESCRIPTION
http://localhost:3000/settings/notification

↑ ここでトークンを取得できる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 設定インターフェースにFirebase Cloud Messaging（FCM）トークンの取得と表示を扱う新しいコンポーネントを追加しました。
	- 通知の処理とトーストの表示にFirebaseメッセージングとSonnerライブラリを統合しました。
	- Webアプリケーションでプッシュ通知を扱うためのFirebase Cloud Messagingサービスワーカー機能を導入しました。
- **ドキュメンテーション**
	- `config`定数の`fcm`オブジェクトに`vapidKey`プロパティを新たに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->