### PR TITLE
レイアウトの余白を調整する

### DIFF
--- a/app/[lang]/generation/_components/editor-config-view/generation-config-models.tsx
+++ b/app/[lang]/generation/_components/editor-config-view/generation-config-models.tsx
@@ -3,7 +3,6 @@
 import { ConfigModelButton } from "@/app/[lang]/generation/_components/editor-config-view/config-model-button"
 import { GenerationModelListButton } from "@/app/[lang]/generation/_components/editor-config-view/generation-model-list-button"
 import { useGenerationContext } from "@/app/[lang]/generation/_hooks/use-generation-context"
-import { CrossPlatformTooltip } from "@/app/_components/cross-platform-tooltip"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { ImageModelsQuery } from "@/graphql/__generated__/graphql"
 
@@ -62,12 +61,6 @@ export const GenerationConfigModels = (props: Props) => {
 
   return (
     <>
-      <div className="flex items-center space-x-2">
-        <h2 className="font-bold text-sm">{"モデル"}</h2>
-        <CrossPlatformTooltip
-          text={"イラストに使用するモデルです、絵柄を変更できます。"}
-        />
-      </div>
       <Tabs defaultValue="normal">
         <TabsList className="w-full">
           <TabsTrigger className="w-full" value="normal">

--- a/app/[lang]/generation/_components/editor-config-view/generation-config-size.tsx
+++ b/app/[lang]/generation/_components/editor-config-view/generation-config-size.tsx
@@ -19,7 +19,7 @@ export const GenerationConfigSize = (props: Props) => {
       <span className="font-bold text-sm">{"サイズ"}</span>
       <Select value={props.value} onValueChange={props.onChange}>
         <SelectGroup>
-          <SelectTrigger>
+          <SelectTrigger className="break-all text-start">
             <SelectValue placeholder="サイズ" />
           </SelectTrigger>
           <SelectContent>

--- a/app/[lang]/generation/_components/editor-config-view/generation-config-view.tsx
+++ b/app/[lang]/generation/_components/editor-config-view/generation-config-view.tsx
@@ -147,7 +147,10 @@ export default function GenerationConfigView() {
   }, [favoritedModels])
 
   return (
-    <GenerationViewCard>
+    <GenerationViewCard
+      title={"モデル"}
+      tooltip={"イラストに使用するモデルです、絵柄を変更できます。"}
+    >
       <ScrollArea type="always">
         <div
           className={cn(
@@ -192,7 +195,7 @@ export default function GenerationConfigView() {
           <Accordion type="single" collapsible>
             <AccordionItem value="setting">
               <AccordionTrigger>詳細設定</AccordionTrigger>
-              <AccordionContent>
+              <AccordionContent className="space-y-2">
                 <GenerationConfigScale
                   value={context.config.scale}
                   onChange={context.updateScale}

--- a/app/[lang]/generation/_components/generation-editor-layout-setting-area.tsx
+++ b/app/[lang]/generation/_components/generation-editor-layout-setting-area.tsx
@@ -69,7 +69,6 @@ export const GenerationEditorLayoutSettingArea = (props: Props) => {
     <>
       <ResizablePanelGroup
         direction="horizontal"
-        style={{ height: "calc(100% - 130px)" }}
         className="mt-2 flex flex-1 flex-col gap-4 overflow-hidden lg:flex-row"
       >
         <ResizablePanel className="lg:min-w-40 xl:min-w-40">

--- a/app/[lang]/generation/_components/generation-view/generation-view.tsx
+++ b/app/[lang]/generation/_components/generation-view/generation-view.tsx
@@ -59,7 +59,7 @@ export const GenerationView = (props: Props) => {
   return (
     <main className="flex flex-col gap-4 overflow-hidden pb-4 lg:h-main lg:flex-row">
       <ResizablePanelGroup direction="horizontal">
-        <ResizablePanel>
+        <ResizablePanel className="flex flex-col">
           <Suspense fallback={<AppLoadingPage />}>{props.header}</Suspense>
           <Suspense fallback={<AppLoadingPage />}>{props.main}</Suspense>
         </ResizablePanel>

--- a/app/[lang]/generation/page.tsx
+++ b/app/[lang]/generation/page.tsx
@@ -45,6 +45,15 @@ const GenerationPage = async () => {
           }
         />
       }
+      main={
+        <GenerationMainView
+          config={<GenerationConfigView />}
+          promptEditor={<GenerationPromptView />}
+          negativePromptEditor={<GenerationNegativePromptView />}
+          taskContentPreview={<GenerationTaskContentPreview />}
+          taskDetails={<GenerationTaskDetailsView />}
+        />
+      }
       aside={
         <GenerationAsideView
           advertising={
@@ -59,15 +68,6 @@ const GenerationPage = async () => {
             </Link>
           }
           taskList={<GenerationTaskListView />}
-          taskDetails={<GenerationTaskDetailsView />}
-        />
-      }
-      main={
-        <GenerationMainView
-          config={<GenerationConfigView />}
-          promptEditor={<GenerationPromptView />}
-          negativePromptEditor={<GenerationNegativePromptView />}
-          taskContentPreview={<GenerationTaskContentPreview />}
           taskDetails={<GenerationTaskDetailsView />}
         />
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- エディタ設定ビューにおいて、ローカライズのための`title`と`tooltip`を含むプロパティを`GenerationViewCard`コンポーネントに追加しました。
- **バグ修正**
	- エディタ設定ビューからモデル選択に関連するツールチップを表示する`CrossPlatformTooltip`コンポーネントを削除しました。
- **スタイル**
	- `GenerationConfigSize`コンポーネントの`SelectTrigger`に`className="break-all text-start"`属性を追加し、スタイリングとレイアウトを改善しました。
	- `GenerationConfigView`の`AccordionContent`コンポーネントと`GenerationView`の`ResizablePanel`コンポーネントに新しい`className`プロパティを追加し、スタイリングを改善しました。
	- `GenerationEditorLayoutSettingArea`コンポーネントの高さを設定する`style`属性を削除し、レイアウトスタイリングに影響を与えました。
- **リファクタ**
	- `GenerationPage`関数内のコンポーネントの順序を変更し、`main`セクションと`aside`セクションの位置を入れ替え、ページのレイアウトを変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->