### PR TITLE
動画のサムネ表示の修正、画像のグラデ表示の修正

### DIFF
--- a/app/routes/($lang)._main._index/_components/home-work-album.tsx
+++ b/app/routes/($lang)._main._index/_components/home-work-album.tsx
@@ -41,7 +41,7 @@ export function HomeWorkAlbum({
           className={"rounded"}
         />
       </Link>
-      <div className="absolute right-0 bottom-0 left-0 box-border flex h-[32%] flex-col justify-end bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-88">
+      <div className="absolute right-0 bottom-0 left-0 box-border flex h-[32%] flex-col justify-end rounded bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-88">
         <Link className="w-48 font-bold" to={`/works/${workId}`}>
           <p className="overflow-hidden text-ellipsis text-nowrap text-white text-xs">
             {workTitle}

--- a/app/routes/($lang)._main._index/_components/home-work-video-album.tsx
+++ b/app/routes/($lang)._main._index/_components/home-work-video-album.tsx
@@ -52,61 +52,65 @@ export function HomeWorkVideoAlbum({
     <div
       className="relative transition-all"
       style={{ ...wrapperStyle, position: "relative" }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
     >
-      <Link className="relative" to={`/works/${workId}`}>
-        <img
-          src={photo.src}
-          // @ts-ignore
-          placeholder={"blurDataURL" in photo ? "blur" : ""}
-          alt={""}
-          className={"rounded"}
-        />
-        {isDesktop && (
-          <video
-            src={url}
-            ref={videoRef}
-            className="absolute top-0 left-0 rounded"
-            style={{ zIndex: "-1" }}
-            muted
-          >
-            <track kind="captions" src={url} label="English" />
-          </video>
-        )}
-        <div className="absolute top-1 left-1 opacity-50">
-          <Badge variant={"secondary"} className="text-xs">
-            {"video"}
-          </Badge>
-        </div>
-      </Link>
-      <div className="absolute right-0 bottom-0 left-0 box-border flex h-[16%] flex-col justify-end bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-80">
-        <Link className="w-48" to={`/works/${workId}`}>
-          <p className="overflow-hidden text-ellipsis text-nowrap text-white text-xs">
-            {workTitle}
-          </p>
-        </Link>
-        <Link to={`/users/${userId}`}>
-          <div className="flex items-center space-x-2">
-            <img
-              src={IconUrl(userIcon)}
-              alt=""
-              className="h-4 w-4 rounded-full"
-            />
-            <span className="text-sm text-white">{userName}</span>
+      <div
+        className="relative inline-block"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <Link to={`/works/${workId}`}>
+          <img
+            src={photo.src}
+            // @ts-ignore
+            placeholder={"blurDataURL" in photo ? "blur" : ""}
+            alt={""}
+            className={"rounded"}
+          />
+          {isDesktop && (
+            <video
+              src={url}
+              ref={videoRef}
+              className="absolute top-0 left-0 rounded"
+              style={{ zIndex: "-1" }}
+              muted
+            >
+              <track kind="captions" src={url} label="English" />
+            </video>
+          )}
+          <div className="absolute top-1 left-1 opacity-50">
+            <Badge variant={"secondary"} className="text-xs">
+              {"video"}
+            </Badge>
           </div>
         </Link>
-      </div>
-      <div className="absolute right-1 bottom-1 z-20">
-        <LikeButton
-          size={56}
-          targetWorkId={workId}
-          targetWorkOwnerUserId={workOwnerUserId}
-          defaultLiked={isLiked}
-          defaultLikedCount={0}
-          isBackgroundNone={true}
-          strokeWidth={2}
-        />
+        <div className="absolute right-0 bottom-0 left-0 box-border rounded flex h-[20%] flex-col justify-end bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-88">
+          <Link to={`/works/${workId}`}>
+            <p className="overflow-hidden text-ellipsis text-nowrap text-white text-xs">
+              {workTitle}
+            </p>
+          </Link>
+          <Link to={`/users/${userId}`}>
+            <div className="flex items-center space-x-2">
+              <img
+                src={IconUrl(userIcon)}
+                alt=""
+                className="h-4 w-4 rounded-full"
+              />
+              <span className="text-sm text-white">{userName}</span>
+            </div>
+          </Link>
+        </div>
+        <div className="absolute right-1 bottom-1 z-20">
+          <LikeButton
+            size={56}
+            targetWorkId={workId}
+            targetWorkOwnerUserId={workOwnerUserId}
+            defaultLiked={isLiked}
+            defaultLikedCount={0}
+            isBackgroundNone={true}
+            strokeWidth={2}
+          />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- マイページで動画サムネが1枚のとき画像動画グラデ領域のサイズが一致していないのを修正
- マイページで動画サムネが1枚のとき右側余白にマウスがあるときも再生されてしまうのを修正
- 動画サムネのグラデーションでタイトル部分に掛かるようにグラデ領域を16%から20%へ変更
- 動画サムネのvideoマークがFirefoxで上にずれるのを修正
- 画像動画サムネのグラデーションをroundedにしてサムネの下側も丸角にする
参考ページ(動画1枚)：https://beta.aipictors.com/users/syuribox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `HomeWorkAlbum`コンポーネントに`rounded`クラスを追加し、レイアウトとスタイリングを改善。
  - `HomeWorkVideoAlbum`コンポーネントの要素構造とスタイルを再編成し、ビジュアルプレゼンテーションを向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->