### PR TITLE
小説コラムのサムネ調整

### DIFF
--- a/app/_components/novel-work-preview-item.tsx
+++ b/app/_components/novel-work-preview-item.tsx
@@ -21,10 +21,10 @@ export const NovelWorkPreviewItem = (props: Props) => {
         <img
           src={props.imageUrl}
           alt="novel work preview"
-          className={"w-full max-w-40 rounded md:max-w-none"}
+          className={"w-full max-w-40 rounded md:max-w-64"}
         />
       </div>
-      <div className="mt-2 h-24 w-48 space-y-2 overflow-hidden text-ellipsis md:w-64">
+      <div className="mt-2 h-24 w-40 space-y-2 overflow-hidden text-ellipsis md:w-64">
         <div className="h-6 overflow-hidden font-bold text-sm">
           {props.title}
         </div>

--- a/app/routes/($lang)._main._index/_components/home-columns-section.tsx
+++ b/app/routes/($lang)._main._index/_components/home-columns-section.tsx
@@ -88,6 +88,7 @@ export const HomeColumnsSection = (props: Props) => {
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
               key={index}
+              className="rounded border-2 border-gray border-solid"
             >
               <div className="relative">
                 <NovelWorkPreviewItem

--- a/app/routes/($lang)._main._index/_components/home-novels-works-section.tsx
+++ b/app/routes/($lang)._main._index/_components/home-novels-works-section.tsx
@@ -57,7 +57,7 @@ export const HomeNovelsWorksSection = (props: Props) => {
       <CarouselWithGradation
         items={works.map((work, index) => (
           // biome-ignore lint/correctness/useJsxKeyInIterable: <explanation>
-          <div>
+          <div className="rounded border-2 border-gray border-solid">
             <div className="relative">
               <NovelWorkPreviewItem
                 workId={work.id}


### PR DESCRIPTION
- 小説コラムサムネの幅をデスクトップ、スマホそれぞれ調整
　→デスクトップは右側の空きを解消
　→スマホは右側に文字が飛び出てたのを修正
- 小説コラムサムネに枠線を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `NovelWorkPreviewItem`コンポーネントにて、画像コンテナの最大幅を`max-w-40`から`max-w-64`に変更し、タイトルコンテナの幅を`w-48`から`w-40`に変更しました。
  - `HomeColumnsSection`コンポーネントに、新しい`className`属性を追加し、スタイルを`"rounded border-2 border-gray border-solid"`に設定しました。
  - `HomeNovelsWorksSection`コンポーネントの`<div>`要素に`className`属性を追加し、スタイルを`"rounded border-2 border-gray border-solid"`に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->