### PR TITLE
ホームのタグ一覧を修正

### DIFF
--- a/app/routes/($lang)._main._index/_components/home-tags-section.tsx
+++ b/app/routes/($lang)._main._index/_components/home-tags-section.tsx
@@ -33,16 +33,18 @@ export const HomeTagsSection = (props: Props) => {
           {props.tags?.map((tag, index) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
             <CarouselItem className="basis-auto" key={index}>
-              <Link className="relative" to={`/tags/${tag.name}`}>
-                <img
-                  className="h-[240px] w-[196px] rounded-md bg-white object-cover object-center transition-opacity duration-200 ease-in-out"
-                  src={tag.thumbnailUrl}
-                  alt={tag.name}
-                />
-                <div className="absolute right-0 bottom-0 left-0 box-border flex h-32 flex-col justify-end bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-80">
-                  <p className="text-white">{`#${tag.name}`}</p>
-                </div>
-              </Link>
+              <div className="relative">
+                <Link to={`/tags/${tag.name}`}>
+                  <img
+                    className="h-[240px] w-[196px] rounded-md bg-white object-cover object-center transition-opacity duration-200 ease-in-out"
+                    src={tag.thumbnailUrl}
+                    alt={tag.name}
+                  />
+                  <div className="absolute right-0 bottom-0 left-0 box-border flex h-32 flex-col justify-end rounded bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-80">
+                    <p className="text-white">{`#${tag.name}`}</p>
+                  </div>
+                </Link>
+              </div>
             </CarouselItem>
           ))}
         </CarouselContent>


### PR DESCRIPTION
- Firefoxでタグ名、グラデが表示されなかったのを修正
- グラデをroundedにする
