### PR TITLE
プロフ背景のグラデ、プロフアイコンサイズの調整

### DIFF
--- a/app/routes/($lang)._main.users.$user/_components/user-home.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-home.tsx
@@ -50,9 +50,12 @@ export const UserHome = (props: UserProfileProps) => {
                   src={props.user.headerImageUrl}
                   alt=""
                 />
-                <div className="absolute bottom-0 left-8 z-20">
+                <div className="absolute bottom-0 left-8 z-30">
                   <UserProfileNameIcon user={props.user} />
                 </div>
+              </div>
+              <div className="absolute right-0 bottom-0 left-0 z-20 h-[25%] bg-gradient-to-t from-[rgba(0,0,0,0.30)] to-transparent p-4 pb-3">
+                &nbsp;
               </div>
             </div>
           ) : (

--- a/app/routes/($lang)._main.users.$user/_components/user-profile-avatar.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-profile-avatar.tsx
@@ -3,7 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/_components/ui/avatar"
 type UserProfileAvatarProps = {
   alt: string
   src?: string
-  size?: "sm" | "md" | "lg"
+  size?: "sm" | "md" | "lg" | "auto"
 }
 
 export const UserProfileAvatar = ({
@@ -11,7 +11,7 @@ export const UserProfileAvatar = ({
   src,
   size = "md",
 }: UserProfileAvatarProps) => {
-  const getSize = (size: "sm" | "md" | "lg") => {
+  const getSize = (size: "sm" | "md" | "lg" | "auto") => {
     switch (size) {
       case "sm":
         return "h-16 w-16"
@@ -19,6 +19,8 @@ export const UserProfileAvatar = ({
         return "h-20 w-20"
       case "lg":
         return "h-32 w-32"
+      case "auto":
+        return "h-20 w-20 md:h-32 md:w-32"
       default:
         return "h-20 w-20"
     }

--- a/app/routes/($lang)._main.users.$user/_components/user-profile-name-icon.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-profile-name-icon.tsx
@@ -26,7 +26,7 @@ export const UserProfileNameIcon = (props: UserProfileProps) => {
               props.user.iconUrl ??
               "https://pub-c8b482e79e9f4e7ab4fc35d3eb5ecda8.r2.dev/no-profile.jpg"
             }
-            size={isDesktop ? "lg" : "md"}
+            size={"auto"}
           />
           <div className="hidden md:block">
             <h1 className="font-bold text-2xl text-white">{props.user.name}</h1>


### PR DESCRIPTION
- プロフ背景をグラデにして画像が白でも名前を読めるように
- プロフアイコンのサイズ調整をコードではなくメディアクエリーに変更 
　→PCで表示直後、小さく表示されるバグの修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `UserProfileAvatar`コンポーネントに新しいサイズオプション「auto」を追加。これにより、アバターのサイズがビューポートに基づいて動的に調整されるようになりました。

- **スタイル**
  - `UserHome`コンポーネントに特定のスタイリングプロパティを持つ新しい`div`要素を追加。

- **リファクタ**
  - `UserProfileNameIcon`コンポーネントの`size`プロップを固定値「auto」に変更し、レンダリングロジックを簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->