### PR TITLE
マイページ小説一覧をflex-warpで再実装

### DIFF
--- a/app/routes/($lang)._main.users.$user.novels/_components/user-novel-list.tsx
+++ b/app/routes/($lang)._main.users.$user.novels/_components/user-novel-list.tsx
@@ -1,3 +1,78 @@
-export const UserNovelList = () => {
-  return <div />
+import { config } from "@/config"
+import { IconUrl } from "@/_components/icon-url"
+import { LikeButton } from "@/_components/like-button"
+import { NovelWorkPreviewItem } from "@/_components/novel-work-preview-item"
+import { UserNameBadge } from "@/_components/user-name-badge"
+import { PhotoAlbum } from "react-photo-album"
+import type { worksQuery } from "@/_graphql/queries/work/works"
+import type { ResultOf } from "gql.tada"
+import { useMediaQuery } from "usehooks-ts"
+
+type Props = {
+  works: NonNullable<ResultOf<typeof worksQuery>["works"]> | null
+  targetRowHeight?: number
+}
+
+/**
+ * 小説作品一覧
+ */
+export const UserNovelList = (props: Props) => {
+  if (!props.works || props.works.length === 0) {
+    return null
+  }
+
+  const workResults = props.works.map((work) => ({
+    id: work.id,
+    src: work.smallThumbnailImageURL,
+    workId: work.id,
+    userId: work.user.id,
+    userIcon: work.user.iconUrl,
+    userName: work.user.name,
+    title: work.title,
+    isLiked: work.isLiked,
+    text: work.title,
+  }))
+
+  const works = workResults
+
+  if (works.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="m-2">
+      <div className="flex-wrap space-y-4 justify-items-center">
+        {works.map((work) => (
+          <div key={work.id}
+            className="relative rounded border-2 border-gray border-solid ml-4 inline-block"
+          >
+            <NovelWorkPreviewItem
+              workId={work.id}
+              imageUrl={work.src}
+              title={work.title}
+              text={work.text ?? ""}
+              tags={[]}
+            />
+            <UserNameBadge
+              userId={work.userId}
+              userIconImageURL={IconUrl(work.userIcon)}
+              name={work.userName}
+              width={"lg"}
+            />
+            <div className="absolute right-0 bottom-0">
+              <LikeButton
+                size={56}
+                targetWorkId={work.id}
+                targetWorkOwnerUserId={work.userId}
+                defaultLiked={work.isLiked}
+                defaultLikedCount={0}
+                isBackgroundNone={true}
+                strokeWidth={2}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/app/routes/($lang)._main.users.$user.novels/_components/user-novels-contents.tsx
+++ b/app/routes/($lang)._main.users.$user.novels/_components/user-novels-contents.tsx
@@ -1,0 +1,74 @@
+import { ResponsivePagination } from "@/_components/responsive-pagination"
+import { AuthContext } from "@/_contexts/auth-context"
+import { worksQuery } from "@/_graphql/queries/work/works"
+import { worksCountQuery } from "@/_graphql/queries/work/works-count"
+import { ParamsError } from "@/_errors/params-error"
+import { UserNovelList } from "@/routes/($lang)._main.users.$user.novels/_components/user-novel-list"
+import { useSuspenseQuery } from "@apollo/client/index"
+import { useParams } from "@remix-run/react"
+import { useContext } from "react"
+
+type Props = {
+  page: number
+  setPage(page: number): void
+  userId: string
+  workType: "NOVEL" | "COLUMN"
+}
+
+export const UserNovelsContents = (props: Props) => {
+  const params = useParams()
+
+  if (params.user === undefined) {
+    throw new ParamsError()
+  }
+  const authContext = useContext(AuthContext)
+
+  const { data: workRes } = useSuspenseQuery(worksQuery, {
+    skip: authContext.isLoading,
+    variables: {
+      offset: props.page * 32,
+      limit: 32,
+      where: {
+        userId: props.userId,
+        isNowCreatedAt: true,
+        ratings: ["G", "R15", "R18", "R18G"],
+        orderBy: "DATE_CREATED",
+        workType: props.workType,
+      },
+    },
+  })
+
+  const worksCountResp = useSuspenseQuery(worksCountQuery, {
+    skip: authContext.isLoading,
+    variables: {
+      where: {
+        userId: props.userId,
+        isNowCreatedAt: true,
+        ratings: ["G", "R15", "R18", "R18G"],
+        workType: props.workType,
+      },
+    },
+  })
+
+  const works = workRes?.works ?? []
+
+  const maxCount = worksCountResp.data?.worksCount ?? 0
+
+  console.log("works", maxCount)
+
+  return (
+    <>
+      <UserNovelList works={works} />
+      <div className="mt-1 mb-1">
+        <ResponsivePagination
+          perPage={32}
+          maxCount={maxCount}
+          currentPage={props.page}
+          onPageChange={(page: number) => {
+            props.setPage(page)
+          }}
+        />
+      </div>
+    </>
+  )
+}

--- a/app/routes/($lang)._main.users.$user/_components/user-contents.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-contents.tsx
@@ -7,6 +7,7 @@ import { UserContentsContainer } from "@/routes/($lang)._main.users.$user/_compo
 import { UserFoldersContents } from "@/routes/($lang)._main.users.$user/_components/user-folders-contents"
 import { UserPickupContents } from "@/routes/($lang)._main.users.$user/_components/user-pickup-contents"
 import { UserStickersContents } from "@/routes/($lang)._main.users.$user/_components/user-stickers-contents"
+import { UserNovelsContents } from "@/routes/($lang)._main.users.$user.novels/_components/user-novels-contents"
 import { UserTabs } from "@/routes/($lang)._main.users.$user/_components/user-tabs"
 import { UserWorksContents } from "@/routes/($lang)._main.users.$user/_components/user-works-contents "
 import type { ResultOf } from "gql.tada"
@@ -92,7 +93,7 @@ export const UserContents = (props: Props) => {
             />
           )}
           {activeTab === "小説" && (
-            <UserWorksContents
+            <UserNovelsContents
               userId={props.user.id}
               page={novelPage}
               setPage={setNovelPage}
@@ -108,7 +109,7 @@ export const UserContents = (props: Props) => {
             />
           )}
           {activeTab === "コラム" && (
-            <UserWorksContents
+            <UserNovelsContents
               userId={props.user.id}
               page={columnPage}
               setPage={setColumnPage}


### PR DESCRIPTION
- 元々ホーム表示と共通のCarouselWithGradationで実装されていたのをflex-warpに変更

![image](https://github.com/aipictors/aipictors/assets/33959988/14c842c4-74ef-462f-b38a-660fa955781f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新しいコンポーネント`UserNovelsContents`を導入し、ユーザーの小説やコラムのコンテンツをタブ選択に基づいて表示します。
- **機能改善**
  - `UserNovelList`コンポーネントが動的に小説作品のリストをユーザー情報や「いいね」機能と一緒に表示できるように拡張されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->