### PR TITLE
人気タグのグラデーションと半透明文字を他と統一

### DIFF
--- a/app/routes/($lang)._main._index/_components/home-tags-section.tsx
+++ b/app/routes/($lang)._main._index/_components/home-tags-section.tsx
@@ -40,7 +40,7 @@ export const HomeTagsSection = (props: Props) => {
                     src={tag.thumbnailUrl}
                     alt={tag.name}
                   />
-                  <div className="absolute right-0 bottom-0 left-0 box-border flex h-32 flex-col justify-end rounded bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-80">
+                  <div className="absolute right-0 bottom-0 left-0 box-border flex h-16 flex-col justify-end rounded bg-gradient-to-t from-black to-transparent p-4 pb-3 opacity-88">
                     <p className="text-white">{`#${tag.name}`}</p>
                   </div>
                 </Link>


### PR DESCRIPTION
- グラデ幅を他と統一してh-16に変更
　他のh-16は一個前のPRでの修正に含まれます。
- 文字の半透明の濃さを80%から88%で他に合わせて、少し濃く見やすく

細かいのばっかりで、申し訳ないです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `HomeTagsSection`コンポーネント内の`div`要素の不透明度を`80`から`88`に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->