### PR TITLE
作品画面の画像とプロフィールの幅の調整

### DIFF
--- a/app/routes/($lang)._main.works.$work/_components/work-container.tsx
+++ b/app/routes/($lang)._main.works.$work/_components/work-container.tsx
@@ -52,7 +52,7 @@ export const WorkContainer = (props: Props) => {
     >
       <div className="flex w-full justify-center overflow-hidden">
         <div className="flex flex-col items-center overflow-hidden">
-          <div className="mx-auto w-full max-w-screen-lg space-y-2">
+          <div className="mx-auto w-full max-w-[1400px] space-y-2">
             <Suspense fallback={<AppLoadingPage />}>
               <WorkArticle work={work} />
             </Suspense>
@@ -76,7 +76,7 @@ export const WorkContainer = (props: Props) => {
             </div>
           </div>
         </div>
-        <div className="mt-2 hidden w-full items-start pl-4 md:mt-0 lg:block lg:max-w-md">
+        <div className="mt-2 hidden w-full items-start pl-4 md:mt-0 lg:block lg:max-w-80">
           <div className="mt-2 md:mt-0">
             <Suspense>
               <WorkUser


### PR DESCRIPTION
- コメントが右から下へ移動したので、右を従来同様に幅を狭くしてみました。
- 左側のviewerの幅の最大を1400pxまで拡大しました。
![image](https://github.com/aipictors/aipictors/assets/33959988/c757d37c-357c-4845-b1a5-92b0a9b0ba88)
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - レイアウトスタイリングのCSSクラスを調整しました。最大幅の制約とスペーシングプロパティが変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->