### PR TITLE
カラーテーマ rev1 part1

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -89,6 +89,27 @@ export function Layout(props: Props) {
         <ThemeProvider
           attribute={"class"}
           defaultTheme={"system"}
+          themes={[
+            "system",
+            "dark",
+            "light",
+            "gray-light",
+            "gray-dark",
+            "red-light",
+            "red-dark",
+            "pink-light",
+            "pink-dark",
+            "orange-light",
+            "orange-dark",
+            "green-light",
+            "green-dark",
+            "blue-light",
+            "blue-dark",
+            "yellow-light",
+            "yellow-dark",
+            "violet-light",
+            "violet-dark",
+          ]}
           enableSystem
           disableTransitionOnChange
         >

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -73,8 +73,40 @@ export const HomeUserNavigationMenu = (props: Props) => {
 
   const { theme, setTheme } = useTheme()
 
+  const setColorTheme = (newMode: string) => {
+    if (newMode === "system") {
+      setTheme(newMode)
+      return
+    }
+    if ((theme === "system" || theme === "dark") && newMode === "light") {
+      setTheme(newMode)
+      return
+    }
+    if ((theme === "system" || theme === "light") && newMode === "dark") {
+      setTheme(newMode)
+      return
+    }
+    // テーマ適用中→"blue-light"、"blue-dark"等同色でのダーク、ライト切り替え
+    const prefix = theme?.replace(/\-(light|dark)/, "-")
+    const colorPrefix = prefix ?? ""
+    setTheme(colorPrefix + newMode)
+  }
+  const setMode = (theme: string) => {
+    if (theme === "system" || theme === "light" || theme === "dark") {
+      return theme
+    }
+    if (theme.endsWith("-light")) {
+      return "light"
+    }
+    if (theme.endsWith("-dark")) {
+      return "dark"
+    }
+    return "system"
+  }
+  const mode = setMode(theme ? theme?.toString() : "system")
+
   const getThemeIcon = () => {
-    return theme === "dark" ? (
+    return theme?.indexOf("dark") !== -1 ? (
       <MoonIcon className="mr-2 inline-block w-4" />
     ) : (
       <SunIcon className="mr-2 inline-block w-4" />
@@ -92,7 +124,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       <DropdownMenuContent>
         <div>
           <div
-            className="w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800"
+            className="w-full rounded-md bg-monotone-200 p-2"
             style={{
               backgroundImage: `url(${headerImageUrl})`,
               backgroundSize: "cover",
@@ -177,11 +209,13 @@ export const HomeUserNavigationMenu = (props: Props) => {
                 <DropdownMenuLabel>{"テーマ変更"}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuRadioGroup
-                  value={theme}
-                  onValueChange={(newTheme) => setTheme(newTheme)}
+                  value={mode}
+                  onValueChange={(newMode) => {
+                    setColorTheme(newMode)
+                  }}
                 >
                   <DropdownMenuRadioItem value="system">
-                    デバイスのモードを使用する
+                    デバイスモード使用
                   </DropdownMenuRadioItem>
                   <DropdownMenuRadioItem value="light">
                     ライト
@@ -190,6 +224,11 @@ export const HomeUserNavigationMenu = (props: Props) => {
                     ダーク
                   </DropdownMenuRadioItem>
                 </DropdownMenuRadioGroup>
+                <MenuItemLink
+                  href="/settings/color"
+                  icon={<SettingsIcon className="mr-2 inline-block w-4" />}
+                  label="その他のカラー"
+                />
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -106,7 +106,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
   const mode = setMode(theme ? theme?.toString() : "system")
 
   const getThemeIcon = () => {
-    return theme?.indexOf("dark") !== -1 ? (
+    return theme?.endsWith("dark") ? (
       <MoonIcon className="mr-2 inline-block w-4" />
     ) : (
       <SunIcon className="mr-2 inline-block w-4" />
@@ -124,7 +124,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       <DropdownMenuContent>
         <div>
           <div
-            className="w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800 p-2"
+            className="w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800"
             style={{
               backgroundImage: `url(${headerImageUrl})`,
               backgroundSize: "cover",

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -124,7 +124,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       <DropdownMenuContent>
         <div>
           <div
-            className="w-full rounded-md bg-monotone-200 p-2"
+            className="w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800 p-2"
             style={{
               backgroundImage: `url(${headerImageUrl})`,
               backgroundSize: "cover",

--- a/app/routes/($lang).settings.color/route.tsx
+++ b/app/routes/($lang).settings.color/route.tsx
@@ -35,14 +35,11 @@ export default function SettingColor() {
       return
     }
     if (color === "none") {
-      setColorSchema("none")
       // "light" || "dark"
       setTheme(mode)
       return
     }
-    const theme = `${color}-${mode}`
-    setColorSchema(theme)
-    setTheme(theme)
+    setTheme(`${color}-${mode}`)
   }
   const setMode = (theme: string) => {
     if (theme === "system" || theme === "light" || theme === "dark") {
@@ -56,15 +53,15 @@ export default function SettingColor() {
     }
     return "system"
   }
-  const mode = setMode(theme ? theme?.toString() : "system")
+  const mode = setMode(theme ? theme : "system")
   const setColorSchema = (theme: string) => {
     if (theme === "system" || theme === "light" || theme === "dark") {
       return "none"
     }
-    const prefix = theme?.replace(/-(light|dark)/, "")
+    const prefix = theme.replace(/\-(light|dark)/, "")
     return prefix ?? "none"
   }
-  const colorSchema = setColorSchema(theme ? theme?.toString() : "none")
+  const colorSchema = setColorSchema(theme ? theme : "system")
   const themeRadio = (value: string, label: string) => {
     return (
       <div className="w-auto">

--- a/app/routes/($lang).settings.color/route.tsx
+++ b/app/routes/($lang).settings.color/route.tsx
@@ -1,0 +1,215 @@
+import { AppPageCenter } from "@/_components/app/app-page-center"
+import { ResponsivePagination } from "@/_components/responsive-pagination"
+import { Button } from "@/_components/ui/button"
+import { Card } from "@/_components/ui/card"
+import { Input } from "@/_components/ui/input"
+import { RadioGroup, RadioGroupItem } from "@/_components/ui/radio-group"
+import { Tabs, TabsList, TabsTrigger } from "@/_components/ui/tabs"
+import { useTheme } from "next-themes"
+import { useState } from "react"
+
+/**
+ * カラーテーマ設定ページ
+ */
+export default function SettingColor() {
+  type SampleTabType = "sampleTab1" | "sampleTab2" | "sampleTab3"
+  const defaultTab = "sampleTab1"
+  const [activeTab, setActiveTab] = useState<SampleTabType>(defaultTab)
+  // TabTriggerがクリックされたときにactiveTabを更新
+  const handleTabClick = (value: SampleTabType) => {
+    setActiveTab(value as SampleTabType)
+  }
+  let activePage = 1
+  // setActiveTab(defaultTab)
+  const setPage = (page: number) => {
+    activePage = page
+  }
+  const handlerInput = (value: string) => {
+    const x = value
+  }
+
+  const { theme, setTheme } = useTheme()
+  const setColorTheme = (mode: string, color: string) => {
+    if (mode === "system") {
+      setTheme("system")
+      return
+    }
+    if (color === "none") {
+      setColorSchema("none")
+      // "light" || "dark"
+      setTheme(mode)
+      return
+    }
+    const theme = `${color}-${mode}`
+    setColorSchema(theme)
+    setTheme(theme)
+  }
+  const setMode = (theme: string) => {
+    if (theme === "system" || theme === "light" || theme === "dark") {
+      return theme
+    }
+    if (theme.endsWith("-light")) {
+      return "light"
+    }
+    if (theme.endsWith("-dark")) {
+      return "dark"
+    }
+    return "system"
+  }
+  const mode = setMode(theme ? theme?.toString() : "system")
+  const setColorSchema = (theme: string) => {
+    if (theme === "system" || theme === "light" || theme === "dark") {
+      return "none"
+    }
+    const prefix = theme?.replace(/-(light|dark)/, "")
+    return prefix ?? "none"
+  }
+  const colorSchema = setColorSchema(theme ? theme?.toString() : "none")
+  const themeRadio = (value: string, label: string) => {
+    return (
+      <div className="w-auto">
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value={value} id={value} />
+          <label htmlFor={value}>{label}</label>
+        </div>
+      </div>
+    )
+  }
+  const themeRadioColor = (
+    value: string,
+    label: string,
+    colorValue: string,
+  ) => {
+    return (
+      <div className="w-auto">
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value={value} id={value} />
+          <label htmlFor={value}>
+            <span className={colorValue}>●</span>
+            {label}
+          </label>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <AppPageCenter>
+      <div className="w-full space-y-8">
+        <p className="font-bold text-2xl">{"カラーテーマ"}</p>
+        <RadioGroup
+          value={mode}
+          name="mode"
+          onValueChange={(value) => {
+            setColorTheme(value, colorSchema)
+            setMode(useTheme().theme ?? "system")
+          }}
+        >
+          {themeRadio("system", "デバイスのモードを使用する")}
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] items-center justify-center gap-2">
+            {themeRadio("light", "ライトモード")}
+            {themeRadio("dark", "ダークモード")}
+          </div>
+          <hr />
+        </RadioGroup>
+        <div>ライトかダークを選択すると色も選べます。</div>
+        <RadioGroup
+          value={colorSchema}
+          name="colorSchema"
+          onValueChange={(value) => {
+            setColorTheme(mode, value)
+            setColorSchema(useTheme().theme ?? "system")
+          }}
+        >
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] items-center justify-center gap-2">
+            {themeRadioColor("none", "デフォルト", "text-white")}
+            {themeRadioColor("gray", "グレー", "text-gray-500")}
+            {themeRadioColor("red", "レッド", "text-red-500")}
+            {themeRadioColor("pink", "ピンク", "text-pink-500")}
+            {themeRadioColor("orange", "オレンジ", "text-orange-500")}
+            {themeRadioColor("green", "グリーン", "text-green-500")}
+            {themeRadioColor("blue", "ブルー", "text-blue-500")}
+            {themeRadioColor("yellow", "イエロー", "text-yellow-500")}
+            {themeRadioColor("violet", "バイオレット", "text-violet-500")}
+          </div>
+        </RadioGroup>
+        UI表示テスト
+        <Card className="mx-3 inline-block h-9 w-24 text-center">
+          カード表示
+        </Card>
+        <div className="mx-3 inline-block h-9 w-20 bg-foreground text-center text-background">
+          反転表示
+        </div>
+        <div className="mx-3 inline-block h-9 w-20 bg-popover text-center text-popover-foreground">
+          メニュー
+        </div>
+        <div className="mx-3 inline-block h-9 w-20 bg-accent text-center text-accent-foreground">
+          アクセント
+        </div>
+      </div>
+      <Button className="m-1" variant="default">
+        ボタン
+      </Button>
+      <Button className="m-1" variant="destructive">
+        destructive
+      </Button>
+      <Button className="m-1" variant="outline">
+        outline
+      </Button>
+      <Button className="m-1" variant="secondary">
+        secondary
+      </Button>
+      <Button className="m-1" variant="ghost">
+        ghost
+      </Button>
+      <Button className="m-1" variant="link">
+        link
+      </Button>
+      <Input
+        className="mx-2 w-80"
+        id="sampleText1"
+        placeholder="プレースホルダー"
+        onChange={(e) => handlerInput(e.target.value)}
+      />
+      <Input
+        className="mx-2 w-80"
+        id="sampleText2"
+        placeholder=""
+        value="入力済み"
+        onChange={(e) => handlerInput(e.target.value)}
+      />
+      <Tabs>
+        <div className="border-b">
+          <TabsList className="mx-0 mb-1 md:mx-4">
+            <TabsTrigger
+              value="sampleTab1"
+              onClick={() => handleTabClick("sampleTab1")}
+            >
+              タブ1
+            </TabsTrigger>
+            <TabsTrigger
+              value="sampleTab2"
+              onClick={() => handleTabClick("sampleTab2")}
+            >
+              タブ2
+            </TabsTrigger>
+            <TabsTrigger
+              value="sampleTab3"
+              onClick={() => handleTabClick("sampleTab3")}
+            >
+              タブ3
+            </TabsTrigger>
+          </TabsList>
+        </div>
+      </Tabs>
+      <ResponsivePagination
+        perPage={32}
+        maxCount={200}
+        currentPage={activePage}
+        onPageChange={(page: number) => {
+          setPage(page)
+        }}
+      />
+    </AppPageCenter>
+  )
+}

--- a/app/routes/($lang).settings/_components/settings-route-list.tsx
+++ b/app/routes/($lang).settings/_components/settings-route-list.tsx
@@ -6,6 +6,7 @@ import {
   ImageIcon,
   MedalIcon,
   StickerIcon,
+  PaletteIcon,
   UserXIcon,
 } from "lucide-react"
 
@@ -35,6 +36,9 @@ export const SettingsRouteList = () => {
       </HomeNavigationButton>
       <HomeNavigationButton href={"/settings/sticker"} icon={StickerIcon}>
         {"スタンプ"}
+      </HomeNavigationButton>
+      <HomeNavigationButton href={"/settings/color"} icon={PaletteIcon}>
+        {"カラーテーマ"}
       </HomeNavigationButton>
       <HomeNavigationButton href={"/settings/request"} icon={MedalIcon}>
         {"チップを受け取る"}

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -25,8 +25,9 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 60 9.1% 97.8%;
     --border: 20 5.9% 82%;
-    --input: 20 5.9% 90%;
+    --input: 20 5.9% 60%;
     --ring: 20 14.3% 4.1%;
+    --main-theme: 0 0% 100%;
     --radius: 0.5rem;
   }
 
@@ -48,9 +49,376 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 60 9.1% 97.8%;
     --border: 12 6.5% 24.0%;
-    --input: 12 6.5% 15.1%;
+    --input: 12 6.5% 40%;
     --ring: 24 5.7% 82.9%;
   }
+
+  .gray-light {
+    --background: 192 0% 95%;
+    --foreground: 192 0% 0%;
+    --card: 192 0% 90%;
+    --card-foreground: 192 0% 10%;
+    --popover: 192 0% 95%;
+    --popover-foreground: 192 95% 0%;
+    --primary: 192 0% 0%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 192 10% 70%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 154 10% 85%;
+    --muted-foreground: 192 0% 35%;
+    --accent: 154 10% 80%;
+    --accent-foreground: 192 0% 10%;
+    --destructive: 0 50% 30%;
+    --destructive-foreground: 192 0% 90%;
+    --border: 192 20% 50%;
+    --input: 192 20% 18%;
+    --ring: 192 0% 0%;
+    --radius: 0.5rem;
+  }
+
+  .gray-dark  {
+    --background: 202 10% 10%;
+    --foreground: 202 0% 100%;
+    --card: 202 0% 10%;
+    --card-foreground: 202 0% 100%;
+    --popover: 202 10% 5%;
+    --popover-foreground: 202 0% 100%;
+    --primary: 202 0% 76%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 202 10% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 164 10% 25%;
+    --muted-foreground: 202 0% 65%;
+    --accent: 164 10% 25%;
+    --accent-foreground: 202 0% 95%;
+    --destructive: 0 50% 50%;
+    --destructive-foreground: 202 0% 100%;
+    --border: 202 20% 50%;
+    --input: 202 20% 50%;
+    --ring: 202 0% 76%;
+    --radius: 0.5rem;
+  }
+  .red-light {
+    --background: 0 100% 95%;
+    --foreground: 0 5% 10%;
+    --card: 0 50% 90%;
+    --card-foreground: 0 5% 15%;
+    --popover: 0 100% 95%;
+    --popover-foreground: 0 100% 10%;
+    --primary: 0 95% 50%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 0 30% 81%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: -38 30% 85%;
+    --muted-foreground: 0 5% 40%;
+    --accent: -38 30% 81%;
+    --accent-foreground: 0 5% 15%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 0 5% 90%;
+    --border: 0 30% 81%;
+    --input: 0 30% 50%;
+    --ring: 0 95% 50%;
+    --radius: 0.5rem;
+  }
+
+  .red-dark {
+    --background: 0 50% 10%;
+    --foreground: 0 5% 90%;
+    --card: 0 50% 10%;
+    --card-foreground: 0 5% 90%;
+    --popover: 0 50% 5%;
+    --popover-foreground: 0 5% 90%;
+    --primary: 0 95% 50%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 0 30% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: -38 30% 25%;
+    --muted-foreground: 0 5% 65%;
+    --accent: -38 30% 25%;
+    --accent-foreground: 0 5% 90%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 0 5% 90%;
+    --border: 0 30% 50%;
+    --input: 0 30% 50%;
+    --ring: 0 95% 50%;
+    --radius: 0.5rem;
+  }
+
+ .pink-light {
+  --background: 310 100% 95%;
+  --foreground: 310 5% 10%;
+  --card: 310 50% 90%;
+  --card-foreground: 310 5% 15%;
+  --popover: 310 100% 95%;
+  --popover-foreground: 310 100% 10%;
+  --primary: 310 95% 50%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 310 30% 81%;
+  --secondary-foreground: 0 0% 0%;
+  --muted: 272 30% 85%;
+  --muted-foreground: 310 5% 40%;
+  --accent: 272 30% 81%;
+  --accent-foreground: 310 5% 15%;
+  --destructive: 0 100% 50%;
+  --destructive-foreground: 310 5% 90%;
+  --border: 310 30% 81%;
+  --input: 310 30% 50%;
+  --ring: 310 95% 50%;
+  --radius: 0.5rem;
+}
+ .pink-dark {
+  --background: 310 50% 10%;
+  --foreground: 310 5% 90%;
+  --card: 310 50% 10%;
+  --card-foreground: 310 5% 90%;
+  --popover: 310 50% 5%;
+  --popover-foreground: 310 5% 90%;
+  --primary: 310 95% 50%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 310 30% 20%;
+  --secondary-foreground: 0 0% 100%;
+  --muted: 272 30% 25%;
+  --muted-foreground: 310 5% 65%;
+  --accent: 272 30% 25%;
+  --accent-foreground: 310 5% 90%;
+  --destructive: 0 100% 50%;
+  --destructive-foreground: 310 5% 90%;
+  --border: 310 30% 50%;
+  --input: 310 30% 50%;
+  --ring: 310 95% 50%;
+  --radius: 0.5rem;
+}
+
+  .orange-light {
+    --background: 34 100% 95%;
+    --foreground: 34 5% 10%;
+    --card: 34 50% 90%;
+    --card-foreground: 34 5% 15%;
+    --popover: 34 100% 95%;
+    --popover-foreground: 34 100% 10%;
+    --primary: 34 95% 50%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 34 30% 81%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: -4 30% 85%;
+    --muted-foreground: 34 5% 40%;
+    --accent: -4 30% 81%;
+    --accent-foreground: 34 5% 15%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 34 5% 90%;
+    --border: 34 30% 81%;
+    --input: 34 30% 50%;
+    --ring: 34 95% 50%;
+    --radius: 0.5rem;
+  }
+
+  .orange-dark {
+    --background: 34 50% 10%;
+    --foreground: 34 5% 90%;
+    --card: 34 50% 10%;
+    --card-foreground: 34 5% 90%;
+    --popover: 34 50% 5%;
+    --popover-foreground: 34 5% 90%;
+    --primary: 34 95% 50%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 34 30% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: -4 30% 25%;
+    --muted-foreground: 34 5% 65%;
+    --accent: -4 30% 25%;
+    --accent-foreground: 34 5% 90%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 34 5% 90%;
+    --border: 34 30% 50%;
+    --input: 34 30% 50%;
+    --ring: 34 95% 50%;
+    --radius: 0.5rem;
+  }
+
+  .green-light {
+    --background: 146 100% 95%;
+    --foreground: 146 5% 10%;
+    --card: 146 50% 90%;
+    --card-foreground: 146 5% 15%;
+    --popover: 146 100% 95%;
+    --popover-foreground: 146 100% 10%;
+    --primary: 146 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 146 30% 82%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 108 30% 85%;
+    --muted-foreground: 146 5% 40%;
+    --accent: 108 30% 82%;
+    --accent-foreground: 146 5% 15%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 146 5% 90%;
+    --border: 146 30% 82%;
+    --input: 146 30% 50%;
+    --ring: 146 93% 24%;
+    --radius: 0.5rem;
+  }
+
+  .green-dark {
+    --background: 146 50% 10%;
+    --foreground: 146 5% 90%;
+    --card: 146 50% 10%;
+    --card-foreground: 146 5% 90%;
+    --popover: 146 50% 5%;
+    --popover-foreground: 146 5% 90%;
+    --primary: 146 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 146 30% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 108 30% 25%;
+    --muted-foreground: 146 5% 65%;
+    --accent: 108 30% 25%;
+    --accent-foreground: 146 5% 90%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 146 5% 90%;
+    --border: 146 30% 50%;
+    --input: 146 30% 50%;
+    --ring: 146 93% 24%;
+    --radius: 0.5rem;
+  }
+
+  .blue-light {
+    --background: 194 100% 95%;
+    --foreground: 194 5% 0%;
+    --card: 194 50% 90%;
+    --card-foreground: 194 5% 10%;
+    --popover: 194 100% 95%;
+    --popover-foreground: 194 100% 0%;
+    --primary: 194 100% 60%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 194 30% 70%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 156 30% 85%;
+    --muted-foreground: 194 5% 35%;
+    --accent: 156 30% 80%;
+    --accent-foreground: 194 5% 10%;
+    --destructive: 0 100% 30%;
+    --destructive-foreground: 194 5% 90%;
+    --border: 194 30% 50%;
+    --input: 194 30% 18%;
+    --ring: 194 100% 60%;
+    --radius: 0.5rem;
+  }
+
+  .blue-dark {
+    --background: 194 50% 5%;
+    --foreground: 194 5% 90%;
+    --card: 194 50% 0%;
+    --card-foreground: 194 5% 90%;
+    --popover: 194 50% 5%;
+    --popover-foreground: 194 5% 90%;
+    --primary: 194 100% 60%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 194 30% 10%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 156 30% 15%;
+    --muted-foreground: 194 5% 60%;
+    --accent: 156 30% 15%;
+    --accent-foreground: 194 5% 90%;
+    --destructive: 0 100% 30%;
+    --destructive-foreground: 194 5% 90%;
+    --border: 194 30% 18%;
+    --input: 194 30% 18%;
+    --ring: 194 100% 60%;
+    --radius: 0.5rem;
+  }
+
+  .yellow-light {
+    --background: 61 100% 95%;
+    --foreground: 61 5% 10%;
+    --card: 61 50% 90%;
+    --card-foreground: 61 5% 15%;
+    --popover: 61 100% 95%;
+    --popover-foreground: 61 100% 10%;
+    --primary: 61 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 61 30% 82%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 23 30% 85%;
+    --muted-foreground: 61 5% 40%;
+    --accent: 23 30% 82%;
+    --accent-foreground: 61 5% 15%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 61 5% 90%;
+    --border: 61 30% 82%;
+    --input: 61 30% 50%;
+    --ring: 61 93% 24%;
+    --radius: 0.5rem;
+  }
+
+  .yellow-dark {
+    --background: 61 50% 10%;
+    --foreground: 61 5% 90%;
+    --card: 61 50% 10%;
+    --card-foreground: 61 5% 90%;
+    --popover: 61 50% 5%;
+    --popover-foreground: 61 5% 90%;
+    --primary: 61 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 61 30% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 23 30% 25%;
+    --muted-foreground: 61 5% 65%;
+    --accent: 23 30% 25%;
+    --accent-foreground: 61 5% 90%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 61 5% 90%;
+    --border: 61 30% 50%;
+    --input: 61 30% 50%;
+    --ring: 61 93% 24%;
+    --radius: 0.5rem;
+  }
+
+  .violet-light {
+    --background: 288 100% 95%;
+    --foreground: 288 5% 10%;
+    --card: 288 50% 90%;
+    --card-foreground: 288 5% 15%;
+    --popover: 288 100% 95%;
+    --popover-foreground: 288 100% 10%;
+    --primary: 288 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 288 30% 82%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 250 30% 85%;
+    --muted-foreground: 288 5% 40%;
+    --accent: 250 30% 82%;
+    --accent-foreground: 288 5% 15%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 288 5% 90%;
+    --border: 288 30% 82%;
+    --input: 288 30% 50%;
+    --ring: 288 93% 24%;
+    --radius: 0.5rem;
+  }
+
+  .violet-dark {
+    --background: 288 50% 10%;
+    --foreground: 288 5% 90%;
+    --card: 288 50% 10%;
+    --card-foreground: 288 5% 90%;
+    --popover: 288 50% 5%;
+    --popover-foreground: 288 5% 90%;
+    --primary: 288 93% 24%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 288 30% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 250 30% 25%;
+    --muted-foreground: 288 5% 65%;
+    --accent: 250 30% 25%;
+    --accent-foreground: 288 5% 90%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 288 5% 90%;
+    --border: 288 30% 50%;
+    --input: 288 30% 50%;
+    --ring: 288 93% 24%;
+    --radius: 0.5rem;
+  }
+
 }
 
 @layer base {

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -25,9 +25,8 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 60 9.1% 97.8%;
     --border: 20 5.9% 82%;
-    --input: 20 5.9% 60%;
+    --input: 20 5.9% 90%;
     --ring: 20 14.3% 4.1%;
-    --main-theme: 0 0% 100%;
     --radius: 0.5rem;
   }
 
@@ -49,7 +48,7 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 60 9.1% 97.8%;
     --border: 12 6.5% 24.0%;
-    --input: 12 6.5% 40%;
+    --input: 12 6.5% 15.1%;
     --ring: 24 5.7% 82.9%;
   }
 


### PR DESCRIPTION
PR分割提案の通りです。
提案いただいたいくつかを追加で採用し、システムを一部更新しています。

色と「ダーク」「ライト」の選択を分離しました。
メイン右メニューから同色のダーク/ライト選択ができます。
system(デバイスのモードを使用)のときは、色はデフォルトになり選択できません。
(これは色名を保存する仕組みが今の所ないからです。実装すればできるかも？)

https://ui.shadcn.com/themes
ここに倣い、デフォルト、グレー、レッド、ピンク、オレンジ、グリーン、ブルー、イエロー、バイオレットにしました。
色数は増えていますが、ダーク分離したことによりテーマの見掛けの数は半分＋2くらいになっています。

https://zippystarter.com/tools/shadcn-ui-theme-generator
それぞれのカラーをここで生成した色に置換しました。
名前によるテーマは廃止されました。

https://github.com/pacocoursey/next-themes/tree/main/examples/multi-theme
本家見本

gray、zinc系のmonotone関連の修正を除外しました。
white→backgroundみたいなのも除外してあります。
ので例えばホームの左右のグラデが背景色にならず白くなったりしています。

ちょっとコードを追加して作り込んでしまったので、バグが心配です。
内部のテーマ名について。
system：デフォルトです。
light：本当のライトモードです。
dark：本当のダークモードです。
[色名]-light：各色のライトモードのテーマ名です。
[色名]-dark：各色の疑似ダークモードのテーマ名です。しかしcssのdark:には反応しません。
cssのdark:に反応しない代用に、monotoneの導入を検討するということですが、そちらはまだ不明です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - アプリに新しいカラーテーマ設定ページを追加しました。ユーザーはシステムモード、ライトモード、ダークモード、特定の色に基づいてテーマを設定できます。
  - ナビゲーションメニューにカラーテーマ設定オプションを追加しました。

- **スタイル**
  - 新しいカラースキームを追加し、ライトおよびダークテーマに対応するCSS変数を導入しました。これにより、アプリ全体のデザイン要素が一貫して表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->