### PR TITLE
カラーテーマ rev1 part2 monotone定義

### DIFF
--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -27,6 +27,16 @@
     --border: 20 5.9% 82%;
     --input: 20 5.9% 90%;
     --ring: 20 14.3% 4.1%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -49,6 +59,16 @@
     --destructive-foreground: 60 9.1% 97.8%;
     --border: 12 6.5% 24.0%;
     --input: 12 6.5% 15.1%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --ring: 24 5.7% 82.9%;
   }
 
@@ -72,6 +92,16 @@
     --border: 192 20% 50%;
     --input: 192 20% 18%;
     --ring: 192 0% 0%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -95,6 +125,16 @@
     --border: 202 20% 50%;
     --input: 202 20% 50%;
     --ring: 202 0% 76%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
   .red-light {
@@ -117,6 +157,16 @@
     --border: 0 30% 81%;
     --input: 0 30% 50%;
     --ring: 0 95% 50%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -140,6 +190,16 @@
     --border: 0 30% 50%;
     --input: 0 30% 50%;
     --ring: 0 95% 50%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -163,6 +223,16 @@
     --border: 310 30% 85%;
     --input: 310 30% 60%;
     --ring: 310 95% 60%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -186,6 +256,16 @@
     --border: 310 30% 60%;
     --input: 310 30% 60%;
     --ring: 310 95% 60%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -209,6 +289,16 @@
     --border: 34 30% 81%;
     --input: 34 30% 50%;
     --ring: 34 95% 50%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
 }
 
@@ -232,6 +322,16 @@
     --border: 34 30% 50%;
     --input: 34 30% 50%;
     --ring: 34 95% 50%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -255,6 +355,16 @@
     --border: 146 30% 82%;
     --input: 146 30% 50%;
     --ring: 146 93% 24%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -278,6 +388,16 @@
     --border: 146 30% 50%;
     --input: 146 30% 50%;
     --ring: 146 93% 24%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -301,6 +421,16 @@
     --border: 194 30% 50%;
     --input: 194 30% 18%;
     --ring: 194 100% 60%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -324,6 +454,16 @@
     --border: 194 30% 18%;
     --input: 194 30% 18%;
     --ring: 194 100% 60%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -347,6 +487,16 @@
     --border: 61 30% 82%;
     --input: 61 30% 50%;
     --ring: 61 93% 24%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -370,6 +520,16 @@
     --border: 61 30% 50%;
     --input: 61 30% 50%;
     --ring: 61 93% 24%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 
@@ -393,6 +553,16 @@
     --border: 288 30% 82%;
     --input: 288 30% 50%;
     --ring: 288 93% 24%;
+    --monotone-50: 0 0% 95%;
+    --monotone-100: 0 0% 90%;
+    --monotone-200: 0 0% 80%;
+    --monotone-300: 0 0% 70%;
+    --monotone-400: 0 0% 60%;
+    --monotone-500: 0 0% 50%;
+    --monotone-600: 0 0% 40%;
+    --monotone-700: 0 0% 30%;
+    --monotone-800: 0 0% 20%;
+    --monotone-900: 0 0% 10%;
     --radius: 0.5rem;
   }
 
@@ -416,6 +586,16 @@
     --border: 288 30% 50%;
     --input: 288 30% 50%;
     --ring: 288 93% 24%;
+    --monotone-50: 0 0% 5%;
+    --monotone-100: 0 0% 10%; 
+    --monotone-200: 0 0% 20%; 
+    --monotone-300: 0 0% 30%; 
+    --monotone-400: 0 0% 40%; 
+    --monotone-500: 0 0% 50%; 
+    --monotone-600: 0 0% 60%; 
+    --monotone-700: 0 0% 70%; 
+    --monotone-800: 0 0% 80%; 
+    --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,6 +60,18 @@ export default {
          */
         "clear-bright-blue": "#0090f0",
         "line-theme": "#06C755",
+        monotone: {
+          50: "hsl(var(--monotone-50))",
+          100: "hsl(var(--monotone-100))",
+          200: "hsl(var(--monotone-200))",
+          300: "hsl(var(--monotone-300))",
+          400: "hsl(var(--monotone-400))",
+          500: "hsl(var(--monotone-500))",
+          600: "hsl(var(--monotone-600))",
+          700: "hsl(var(--monotone-700))",
+          800: "hsl(var(--monotone-800))",
+          900: "hsl(var(--monotone-900))",
+        },
       },
       /**
        * shadcn/ui


### PR DESCRIPTION
CSS色名のclassであるmonotone定義を追加します。
part2は色定義だけ入れてあり、実際のhtml/className側へは反映を入れていません。
利用目的は、ライト系のときとダーク系のときで色の濃さが反転するようにしてあるため「gray-100 dark:gray-900」のような表記でダーク対応しているものを、正式なダークではない他の色テーマに拡張することができます。

現時点の実装は、色が完全に黒と白を割っただけなので、grayやzincとは色味が違います。
またこの時点では、カラーテーマごとの最大の濃さなども考慮に入っていません。
（それぞれ定義すればできますが、計算して書くのは少し大変です）
例えばライト系でmonotone-50よりも普通の背景のほうが黒っぽい等あるかもしれません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しいカラーパレット「monotone」を追加しました。このパレットは50から900までの様々な濃淡を持ちます。
	- 新しいカスタムプロパティを追加しました。これにより、CSSスタイリングがより柔軟になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->