### PR TITLE
カラーテーマ rev1 part3 背景色・文字色に合わせる

### DIFF
--- a/app/_components/carousel-with-gradation.tsx
+++ b/app/_components/carousel-with-gradation.tsx
@@ -32,9 +32,9 @@ export const CarouselWithGradation = (props: Props) => {
           <CarouselItem className="relative w-16 basis-1/3.5 space-y-2" />
           <div className="relative basis-1/3.5 space-y-2" />
         </CarouselContent>
-        <div className="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-white to-transparent dark:from-card dark:to-transparent" />
+        <div className="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-background to-transparent" />
         <CarouselPrevious className="absolute left-0" />
-        <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-white dark:to-card" />
+        <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-background " />
         <CarouselNext className="absolute right-0" />
       </Carousel>
     </>

--- a/app/_components/full-screen-container.tsx
+++ b/app/_components/full-screen-container.tsx
@@ -44,7 +44,7 @@ export const FullScreenContainer = (props: Props) => {
     <div
       className={cn(
         `${props.enabledScroll ? "overflow-hidden" : ""}`,
-        "fixed top-0 left-0 z-50 h-[100vh] w-[100vw] bg-white dark:bg-black",
+        "fixed top-0 left-0 z-50 h-[100vh] w-[100vw] bg-background",
       )}
     >
       <div

--- a/app/_components/like-button.tsx
+++ b/app/_components/like-button.tsx
@@ -73,15 +73,13 @@ export const LikeButton = ({
               }}
             >
               <Heart
-                className={"fill-white text-black dark:text-white"}
+                className={"fill-white text-foreground"}
                 size={Math.floor(size / 2)}
                 strokeWidth={1}
               />
             </div>
             {text && (
-              <span className={cn("mr-3 text-black text-sm dark:text-white")}>
-                {text}
-              </span>
+              <span className={cn("mr-3 text-foreground text-sm")}>{text}</span>
             )}
           </button>
         }
@@ -178,8 +176,8 @@ export const LikeButton = ({
             isLiked
               ? "fill-rose-500 text-rose-500"
               : isBackgroundNone
-                ? "fill-white text-black dark:text-white"
-                : "fill-transparent text-black dark:text-white",
+                ? "fill-white text-foreground"
+                : "fill-transparent text-foreground",
             isLiked ? "like-animation" : "like-animation-end",
           )}
           size={Math.floor(size / 2)}
@@ -188,7 +186,7 @@ export const LikeButton = ({
         />
       </div>
       {text && (
-        <span className={cn("mr-3 text-black text-sm dark:text-white")}>
+        <span className={cn("mr-3 text-foreground text-sm")}>
           {text}
           {likedCount}
         </span>

--- a/app/_components/responsive-pagination.tsx
+++ b/app/_components/responsive-pagination.tsx
@@ -80,7 +80,7 @@ export const ResponsivePagination = ({
           <Button
             className={
               isActiveButtonStyle
-                ? "bg-black text-white hover:bg-black hover:text-white dark:bg-white dark:text-black dark:hover:bg-white"
+                ? "bg-foreground text-background hover:bg-foreground hover:text-background"
                 : ""
             }
           >

--- a/app/routes/($lang)._main._index/_components/home-tag-list.tsx
+++ b/app/routes/($lang)._main._index/_components/home-tag-list.tsx
@@ -35,7 +35,7 @@ export const HomeTagList = (props: Props) => {
         ))}
         <CarouselItem className="relative w-16 basis-1/3.5 space-y-2" />
       </CarouselContent>
-      <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-white dark:to-black" />
+      <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-background" />
     </Carousel>
   )
 }

--- a/app/routes/($lang)._main._index/_components/home-tags-section.tsx
+++ b/app/routes/($lang)._main._index/_components/home-tags-section.tsx
@@ -48,7 +48,7 @@ export const HomeTagsSection = (props: Props) => {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-white dark:to-black" />
+        <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-background" />
       </Carousel>
     </>
   )

--- a/app/routes/($lang)._main.posts.$post/_components/work-action-bookmark.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-action-bookmark.tsx
@@ -75,11 +75,7 @@ export const WorkActionBookmark = (props: Props) => {
         <Loader2Icon className="h-4 w-4 animate-spin" />
       ) : (
         <FolderIcon
-          className={
-            isBookmarked
-              ? "fill-black dark:fill-white"
-              : "fill-white dark:fill-black"
-          }
+          className={isBookmarked ? "fill-foreground" : "fill-background"}
         />
       )}
     </Button>

--- a/app/routes/($lang)._main.posts.$post/_components/work-image-thumbnail-carousel.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-image-thumbnail-carousel.tsx
@@ -53,9 +53,9 @@ export const WorkImageThumbnailCarousel: React.FC<
           )
         })}
       </CarouselContent>
-      <div className="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-white to-transparent dark:from-card dark:to-transparent" />
+      <div className="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-background to-transparent" />
       <CarouselPrevious className="absolute left-0" />
-      <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-white dark:to-card" />
+      <div className="absolute top-0 right-0 h-full w-16 bg-gradient-to-r from-transparent to-background" />
       <CarouselNext className="absolute right-0" />
     </Carousel>
   )


### PR DESCRIPTION
monotoneではなく、背景色、文字色に合わせる部分の変更です。

`carousel-with-gradation.tsx`　ホームやpostsの関連作品のカルーセルのグラデーション
`full-screen-container.tsx`　投稿、編集画面のモザイク修正画面の左ツールバーの背景色
`like-button.tsx`　postsのメインのイイネボタン。このボタンの♡は他と違い普通の文字のように振舞う
`responsive-pagination.tsx`　isActiveButtonStyleは未使用。
`home-tags-section.tsx`　ホームの人気タグのグラデーション
`work-action-bookmark.tsx`　フォルダボタンの中身
`work-image-thumbnail-carousel.tsx`　postsの複数ファイルの画像選択

monotone周りはpart4へ送ります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - カルーセルコンポーネントのグラデーション色を汎用的なものに変更しました。
  - フルスクリーンコンテナの背景色を変更しました。

- **スタイル**
  - Likeボタンのアイコンとテキストの色を条件に応じて調整しました。
  - レスポンシブページネーションのボタンの色を更新しました。
  - ホームタグセクションの背景グラデーション色を変更しました。
  - ブックマークアイコンのスタイルを`isBookmarked`プロパティに基づいて更新しました。
  - ホームタグリストの背景プロパティを更新しました。

- **バグ修正**
  - カルーセル内の`div`要素のグラデーション色を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->