### PR TITLE
カラーテーマ rev1 part4 monotone系定義および投稿編集画面修正

### DIFF
--- a/app/_components/button/glowing-gradient-border-button.tsx
+++ b/app/_components/button/glowing-gradient-border-button.tsx
@@ -18,12 +18,12 @@ export function GlowingGradientBorderButton(props: Props) {
       type={"button"}
       onClick={props.onClick}
       // biome-ignore lint/nursery/useSortedClasses: <explanation>
-      className={` bg-gray-50 dark:bg-black m-4 relative ${props.className}`}
+      className={`bg-monotone-50 m-4 relative ${props.className}`}
     >
       <div className="mx-auto max-w-7xl">
         <div className="group relative cursor-pointer">
           <div className="-inset-1 absolute rounded-lg bg-gradient-to-r from-red-600 to-violet-600 opacity-25 blur transition duration-1000 group-hover:opacity-90 group-hover:duration-200 dark:opacity-75" />
-          <div className="items-top relative flex justify-center space-x-6 rounded-lg bg-white px-4 py-4 leading-none ring-1 ring-gray-900/5 dark:text-black">
+          <div className="items-top relative flex justify-center space-x-6 rounded-lg bg-white px-4 py-4 text-black leading-none ring-1 ring-gray-900/5">
             {props.children}
           </div>
         </div>

--- a/app/_components/button/gradient-border-button.tsx
+++ b/app/_components/button/gradient-border-button.tsx
@@ -20,7 +20,7 @@ export function GradientBorderButton(props: Props) {
       type="button"
       disabled={props.disabled}
       // biome-ignore lint/nursery/useSortedClasses: <explanation>
-      className={`flex items-center h-10 font-medium hover:opacity-80 duration-200 rounded-lg bg-gradient-to-tr from-pink-300 to-blue-300 p-1 dark:text-black ${props.className}`}
+      className={`flex items-center h-10 font-medium hover:opacity-80 duration-200 rounded-lg bg-gradient-to-tr from-pink-300 to-blue-300 p-1 text-black ${props.className}`}
     >
       <div
         className={

--- a/app/_components/button/rounded-light-button.tsx
+++ b/app/_components/button/rounded-light-button.tsx
@@ -15,7 +15,7 @@ export function RoundedLightButton(props: Props) {
       type="button"
       disabled={props.disabled}
       className={`flex items-center justify-center rounded-full p-1 pl-2 text-sm duration-200 hover:opacity-80${
-        props.isActive ? " bg-zinc-100 dark:bg-zinc-800" : " bg-transparent"
+        props.isActive ? " bg-monotone-100 text-foreground" : " bg-transparent"
       }`}
     >
       {props.children}

--- a/app/_components/image-generation-reference-card.tsx
+++ b/app/_components/image-generation-reference-card.tsx
@@ -13,10 +13,10 @@ type Props = {
 export const ImageGenerationReferenceCard = (props: Props) => {
   return (
     <Link
-      className="bg-gray-100 dark:bg-gray-900"
+      className="bg-monotone-100"
       to={`/generation?prompts=${encodeURIComponent(props.prompts)}`}
     >
-      <div className="rounded-md bg-gray-100 p-4 dark:bg-gray-900">
+      <div className="rounded-md bg-monotone-100 p-4">
         <div className="relative m-auto max-w-64">
           <Card className="relative z-10 bg-white">{props.children}</Card>
           <div className="ta-c relative z-10 m-auto mb-4 text-sm">

--- a/app/_components/images-preview.tsx
+++ b/app/_components/images-preview.tsx
@@ -271,7 +271,7 @@ export const ImagesPreview = (props: Props) => {
     <div className="flex flex-col space-y-2">
       <div className="relative">
         {/* Display thumbnail */}
-        <div className="m-auto flex h-full max-h-[64vh] w-auto cursor-pointer justify-center overflow-x-auto rounded bg-card bg-gray-100 object-contain dark:bg-zinc-900">
+        <div className="m-auto flex h-full max-h-[64vh] w-auto cursor-pointer justify-center overflow-x-auto rounded bg-monotone-100 object-contain">
           {props.imageURLs.length > 1 && (
             <Badge
               variant="secondary"
@@ -282,7 +282,7 @@ export const ImagesPreview = (props: Props) => {
           )}
           <div className="inline-block overflow-hidden text-center">
             <img
-              className="m-auto h-full max-h-[64vh] w-auto cursor-pointer rounded bg-card bg-zinc-100 object-contain dark:bg-zinc-900"
+              className="m-auto h-full max-h-[64vh] w-auto cursor-pointer rounded bg-monotone-100 object-contain"
               draggable={false}
               key={props.thumbnailUrl}
               alt="thumbnail"

--- a/app/_components/page/login-page.tsx
+++ b/app/_components/page/login-page.tsx
@@ -107,7 +107,7 @@ export const LoginPage = () => {
           </div>
         </div>
         <div className="hidden h-full w-full flex-1 lg:block">
-          <Card className="h-full w-full bg-zinc-200 p-4 dark:bg-zinc-500">
+          <Card className="h-full w-full bg-monotone-200 p-4 dark:bg-zinc-500">
             <p className="text-sm">{"aipictors.com"}</p>
             <AppCanvas />
           </Card>

--- a/app/_components/paint-canvas.tsx
+++ b/app/_components/paint-canvas.tsx
@@ -496,9 +496,7 @@ const PaintCanvas: React.FC<IProps> = ({
         <div className="mb-1 flex md:flex-col">
           {!isMosaicMode && (
             <Button
-              className={cn(
-                tool === "brush" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-              )}
+              className={cn(tool === "brush" ? "mr-2 bg-monotone-200" : "mr-2")}
               size="icon"
               variant="ghost"
               onClick={() => setTool("brush")}
@@ -508,9 +506,7 @@ const PaintCanvas: React.FC<IProps> = ({
           )}
           {!isMosaicMode && (
             <Button // 2. 投げ縄ボタンを追加
-              className={cn(
-                tool === "lasso" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-              )}
+              className={cn(tool === "lasso" ? "mr-2 bg-monotone-200" : "mr-2")}
               size="icon"
               variant="ghost"
               onClick={() => setTool("lasso")}
@@ -521,9 +517,7 @@ const PaintCanvas: React.FC<IProps> = ({
           {isMosaicMode && (
             <Button // 2. 投げ縄ボタンを追加
               className={cn(
-                tool === "lasso-mosaic"
-                  ? "mr-2 bg-gray-200 dark:bg-gray-800"
-                  : "mr-2",
+                tool === "lasso-mosaic" ? "mr-2 bg-monotone-200" : "mr-2",
               )}
               size="icon"
               variant="ghost"
@@ -534,9 +528,7 @@ const PaintCanvas: React.FC<IProps> = ({
           )}
 
           <Button
-            className={cn(
-              tool === "eraser" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-            )}
+            className={cn(tool === "eraser" ? "mr-2 bg-monotone-200" : "mr-2")}
             size="icon"
             variant="ghost"
             onClick={() => setTool("eraser")}
@@ -634,7 +626,7 @@ const PaintCanvas: React.FC<IProps> = ({
         </div>
         <div
           className={cn(
-            "flex h-[100%] w-full items-center justify-center overflow-hidden border border-gray-300 bg-gray-100 dark:border-gray-600 dark:bg-gray-900",
+            "flex h-[100%] w-full items-center justify-center overflow-hidden border border-gray-300 bg-monotone-100 dark:border-gray-600",
           )}
         >
           <div

--- a/app/_components/sort-list-selector.tsx
+++ b/app/_components/sort-list-selector.tsx
@@ -19,7 +19,7 @@ export const SortListSelector = (props: Props) => {
             onKeyUp={item.callback}
             onKeyDown={item.callback}
             onKeyPress={item.callback}
-            className="flex w-full cursor-pointer items-center p-4 transition-all hover:bg-gray-100 dark:hover:bg-gray-800"
+            className="flex w-full cursor-pointer items-center p-4 transition-all hover:bg-monotone-200"
           >
             {props.nowSortType === item.sortType ? (
               <CheckIcon className="mr-2 w-4" />

--- a/app/routes/($lang)._main._index/_components/home-notifications-comments-tabs.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-comments-tabs.tsx
@@ -29,7 +29,7 @@ export const HomeNotificationCommentsTabs = () => {
     <>
       <ScrollArea className="relative h-96 overflow-y-auto">
         <Tabs
-          className="sticky top-0 z-10 bg-white pt-1 dark:bg-zinc-900"
+          className="sticky top-0 z-10 bg-background pt-1 dark:bg-zinc-900"
           defaultValue={defaultTab}
         >
           <div className="border-b">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-award-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-award-item.tsx
@@ -17,7 +17,7 @@ export const HomeNotificationsContentAwardItem = (props: Props) => {
     <>
       <Link
         to={`/posts/${props.workId}`}
-        className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center p-1 transition-all hover:bg-monotone-100 hover:dark:bg-zinc-900"
       >
         <>
           <div className="h-12 w-12 overflow-hidden rounded-md">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-commented-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-commented-item.tsx
@@ -34,7 +34,7 @@ export const HomeNotificationsContentCommentedItem = (props: Props) => {
       <div className="flex flex-col space-y-1 border-b p-1">
         <Link
           to={`/posts/${props.workId}`}
-          className="flex items-center rounded-md p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+          className="flex items-center rounded-md p-1 transition-all hover:bg-monotone-100 hover:dark:bg-zinc-900"
         >
           <>
             <img

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-followed-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-followed-item.tsx
@@ -19,7 +19,7 @@ export const HomeNotificationsContentFollowedItem = (props: Props) => {
   return (
     <>
       <Link
-        className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center p-1 transition-all hover:bg-monotone-100 hover:dark:bg-zinc-900"
         to={`/users/${props.userId}`}
       >
         <img

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-liked-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-liked-item.tsx
@@ -20,7 +20,7 @@ export const HomeNotificationsContentLikedItem = (props: Props) => {
       {props.workId && (
         <Link
           to={`/posts/${props.workId}`}
-          className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+          className="flex items-center p-1 transition-all hover:bg-monotone-100 hover:dark:bg-zinc-900"
         >
           <>
             <div className="h-12 w-12 overflow-hidden rounded-md">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-reply-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-reply-item.tsx
@@ -22,7 +22,7 @@ export const HomeNotificationsContentReplyItem = (props: Props) => {
     <>
       <Link
         to={`/posts/${props.workId}`}
-        className="flex items-center border-b p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center border-b p-1 transition-all hover:bg-monotone-100 hover:dark:bg-zinc-900"
       >
         <Link to={`/users/${props.ownerUserId}`}>
           <img

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -124,7 +124,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       <DropdownMenuContent>
         <div>
           <div
-            className="relative mb-4 h-16 w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800"
+            className="relative mb-4 h-16 w-full rounded-md bg-monotone-200 p-2"
             style={{
               backgroundImage: `url(${headerImageUrl})`,
               backgroundSize: "cover",

--- a/app/routes/($lang)._main.new.image/_components/ad-work-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/ad-work-input.tsx
@@ -14,7 +14,7 @@ type Props = {
 export const AdWorkInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">宣伝作品</p>
           <div className="mb-1 items-center text-sm opacity-65">

--- a/app/routes/($lang)._main.new.image/_components/caption-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/caption-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const CaptionInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">
             {props.label ? props.label : "キャプション（任意）"}

--- a/app/routes/($lang)._main.new.image/_components/category-editable-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/category-editable-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const CategoryEditableInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">タグの編集許可</p>
           <div className="flex items-center space-x-2">

--- a/app/routes/($lang)._main.new.image/_components/comments-editable-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/comments-editable-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const CommentsEditableInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">コメント許可</p>
           <div className="flex items-center space-x-2">

--- a/app/routes/($lang)._main.new.image/_components/date-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/date-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const DateInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">予約投稿</p>
           <div className="block md:flex">

--- a/app/routes/($lang)._main.new.image/_components/event-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/event-input.tsx
@@ -43,7 +43,7 @@ export const EventInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{"イベント"}</p>
           <div className="items-center">

--- a/app/routes/($lang)._main.new.image/_components/generation-params-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/generation-params-input.tsx
@@ -32,7 +32,7 @@ export const GenerationParamsInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">生成情報</p>
           <p className="mb-1 text-xs">プロンプト</p>

--- a/app/routes/($lang)._main.new.image/_components/new-image-form.tsx
+++ b/app/routes/($lang)._main.new.image/_components/new-image-form.tsx
@@ -628,7 +628,7 @@ export const NewImageForm = () => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-monotone-100 dark:bg-black">
           <div
             // biome-ignore lint/nursery/useSortedClasses: <explanation>
             className={`relative items-center bg-gray-800 ${
@@ -891,7 +891,7 @@ export const NewImageForm = () => {
             />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2 dark:bg-black">
           <Button className="w-full" type="submit" onClick={onPost}>
             投稿
           </Button>

--- a/app/routes/($lang)._main.new.image/_components/rating-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/rating-input.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const RatingInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">年齢制限</p>
           <RadioGroup

--- a/app/routes/($lang)._main.new.image/_components/related-link-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/related-link-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const RelatedLinkInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{"関連リンク"}</p>
           <Input

--- a/app/routes/($lang)._main.new.image/_components/series-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/series-input.tsx
@@ -21,7 +21,7 @@ type Props = {
 export const AlbumInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">シリーズ</p>
           <Select

--- a/app/routes/($lang)._main.new.image/_components/success-created-work-dialog.tsx
+++ b/app/routes/($lang)._main.new.image/_components/success-created-work-dialog.tsx
@@ -83,7 +83,7 @@ export const SuccessCreatedWorkDialog = (props: Props) => {
           <div className="relative h-40 w-full">
             <div
               id="confetti-container"
-              className="relative h-40 w-full overflow-hidden bg-zinc-100 dark:bg-zinc-900"
+              className="relative h-40 w-full overflow-hidden bg-monotone-100 dark:bg-zinc-900"
             />
             {props.createdAt > new Date().getTime() ? (
               <Link to={"/dashboard/posts"}>

--- a/app/routes/($lang)._main.new.image/_components/tag-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/tag-input.tsx
@@ -19,7 +19,7 @@ export const TagsInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{`タグ (${props.tags.length}/10)`}</p>
           <TagInput

--- a/app/routes/($lang)._main.new.image/_components/taste-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/taste-input.tsx
@@ -18,7 +18,7 @@ type Props = {
 export const TasteInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">テイスト</p>
           <Select

--- a/app/routes/($lang)._main.new.image/_components/theme-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/theme-input.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const ThemeInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">お題参加</p>
           {props.isLoading ? (

--- a/app/routes/($lang)._main.new.image/_components/title-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/title-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const TitleInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="flex flex-col">
           <p className="mb-1 font-bold text-sm">
             {props.label ? props.label : "タイトル（必須）"}

--- a/app/routes/($lang)._main.new.image/_components/view-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/view-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const ViewInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-background pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">公開モード</p>
           <RadioGroup

--- a/app/routes/($lang)._main.new.text/_components/new-text-form.tsx
+++ b/app/routes/($lang)._main.new.text/_components/new-text-form.tsx
@@ -638,7 +638,7 @@ export const NewTextForm = () => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-monotone-100 dark:bg-black">
           <CropImageField
             isHidePreviewImage={thumbnailBase64 === ""}
             cropWidth={400}
@@ -851,7 +851,7 @@ export const NewTextForm = () => {
             />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2 dark:bg-black">
           <Button className="w-full" type="submit" onClick={onPost}>
             投稿
           </Button>

--- a/app/routes/($lang)._main.posts.$post.edit._index/_components/edit-image-form.tsx
+++ b/app/routes/($lang)._main.posts.$post.edit._index/_components/edit-image-form.tsx
@@ -734,7 +734,7 @@ export const EditImageForm = (props: Props) => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-monotone-100 dark:bg-black">
           <div
             // biome-ignore lint/nursery/useSortedClasses: <explanation>
             className={`relative items-center pb-2 bg-gray-800 ${
@@ -1001,7 +1001,7 @@ export const EditImageForm = (props: Props) => {
             <AdWorkInput isChecked={isAd} onChange={setIsAd} />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2 dark:bg-black">
           <Button className="w-full" type="submit" onClick={onPost}>
             更新
           </Button>

--- a/app/routes/($lang)._main.posts.$post/_components/work-html-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-html-view.tsx
@@ -5,7 +5,7 @@ type Props = {
 
 export const WorkHtmlView = ({ thumbnailUrl, html }: Props) => {
   return (
-    <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+    <div className="relative m-0 bg-monotone-50 dark:bg-zinc-950">
       <img
         src={thumbnailUrl}
         alt="Thumbnail"

--- a/app/routes/($lang)._main.posts.$post/_components/work-image-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-image-view.tsx
@@ -48,7 +48,7 @@ export const WorkImageView = ({ workImageURL, subWorkImageURLs }: Props) => {
 
   if (workImageURL) {
     return (
-      <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+      <div className="relative m-0 bg-monotone-100 dark:bg-zinc-950">
         <ImagesPreview
           currentIndex={0}
           setCurrentIndex={() => {}}

--- a/app/routes/($lang)._main.posts.$post/_components/work-video-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-video-view.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const WorkVideoView = ({ videoUrl }: Props) => {
   return (
-    <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+    <div className="relative m-0 bg-monotone-100 dark:bg-zinc-950">
       <video
         controls
         className="m-auto h-auto w-auto object-contain xl:max-h-[80vh]"

--- a/app/routes/($lang)._main.users.$user/_components/user-home-main.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-home-main.tsx
@@ -42,7 +42,7 @@ export const UserHomeMain = (props: Props) => {
   const isFollow = userInfo?.user?.isFollowee ?? false
 
   return (
-    <div className="relative m-auto h-64 w-full bg-neutral-100 md:h-24 dark:bg-neutral-900">
+    <div className="relative m-auto h-64 w-full bg-monotone-50 md:h-24 dark:bg-neutral-900">
       <div className="absolute top-8 right-0 hidden md:block">
         <div className="flex items-center space-x-2">
           <FollowButton

--- a/app/routes/($lang).dashboard._index/_components/dashboard-home-content-container.tsx
+++ b/app/routes/($lang).dashboard._index/_components/dashboard-home-content-container.tsx
@@ -9,8 +9,8 @@ type Props = {
 export const DashboardHomeContentContainer = (props: Props) => {
   return (
     <>
-      <div className="h-auto rounded-md bg-zinc-50 md:h-[640px] dark:bg-zinc-700">
-        <div className="w-full rounded-t-md bg-zinc-100 p-4 font-bold dark:bg-zinc-800">
+      <div className="h-auto rounded-md bg-monotone-50 md:h-[640px] dark:bg-zinc-700">
+        <div className="w-full rounded-t-md bg-monotone-100 p-4 font-bold dark:bg-zinc-800">
           {props.title}
         </div>
         {props.children}


### PR DESCRIPTION
monotone関連の修正を入れます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - ボタンコンポーネントの背景色クラスとテキスト色を更新。
  - ホバースタイルを`hover:bg-monotone-200`に変更。
  - 各ツール（ブラシ、ラッソ、ラッソモザイク、消しゴム）のボタンスタイルを単色の色に更新。
  - 背景色クラスを`bg-background`に変更。

- **UI改善**
  - ホーム通知コンテンツのホバースタイルを単色に変更。
  - フォームコンポーネントの背景色を単色に変更。

これらの変更は、UIの一貫性と視覚的な統一性を向上させるために行われました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->