### PR TITLE
カラーテーマ rev2 part4 monotoneの代わりに、card、primary、secondaryなどを使用する

### DIFF
--- a/app/_components/button/rounded-light-button.tsx
+++ b/app/_components/button/rounded-light-button.tsx
@@ -15,7 +15,9 @@ export function RoundedLightButton(props: Props) {
       type="button"
       disabled={props.disabled}
       className={`flex items-center justify-center rounded-full p-1 pl-2 text-sm duration-200 hover:opacity-80${
-        props.isActive ? " bg-zinc-100 dark:bg-zinc-800" : " bg-transparent"
+        props.isActive
+          ? " bg-secondary text-secondary-foreground"
+          : " bg-transparent"
       }`}
     >
       {props.children}

--- a/app/_components/image-generation-reference-card.tsx
+++ b/app/_components/image-generation-reference-card.tsx
@@ -13,10 +13,10 @@ type Props = {
 export const ImageGenerationReferenceCard = (props: Props) => {
   return (
     <Link
-      className="bg-gray-100 dark:bg-gray-900"
+      className="bg-card"
       to={`/generation?prompts=${encodeURIComponent(props.prompts)}`}
     >
-      <div className="rounded-md bg-gray-100 p-4 dark:bg-gray-900">
+      <div className="rounded-md bg-card p-4">
         <div className="relative m-auto max-w-64">
           <Card className="relative z-10 bg-white">{props.children}</Card>
           <div className="ta-c relative z-10 m-auto mb-4 text-sm">

--- a/app/_components/images-preview.tsx
+++ b/app/_components/images-preview.tsx
@@ -271,7 +271,7 @@ export const ImagesPreview = (props: Props) => {
     <div className="flex flex-col space-y-2">
       <div className="relative">
         {/* Display thumbnail */}
-        <div className="m-auto flex h-full max-h-[64vh] w-auto cursor-pointer justify-center overflow-x-auto rounded bg-card bg-gray-100 object-contain dark:bg-zinc-900">
+        <div className="m-auto flex h-full max-h-[64vh] w-auto cursor-pointer justify-center overflow-x-auto rounded bg-card object-contain dark:bg-zinc-900">
           {props.imageURLs.length > 1 && (
             <Badge
               variant="secondary"
@@ -282,7 +282,7 @@ export const ImagesPreview = (props: Props) => {
           )}
           <div className="inline-block overflow-hidden text-center">
             <img
-              className="m-auto h-full max-h-[64vh] w-auto cursor-pointer rounded bg-card bg-zinc-100 object-contain dark:bg-zinc-900"
+              className="m-auto h-full max-h-[64vh] w-auto cursor-pointer rounded bg-card object-contain dark:bg-zinc-900"
               draggable={false}
               key={props.thumbnailUrl}
               alt="thumbnail"

--- a/app/_components/page/login-page.tsx
+++ b/app/_components/page/login-page.tsx
@@ -107,7 +107,7 @@ export const LoginPage = () => {
           </div>
         </div>
         <div className="hidden h-full w-full flex-1 lg:block">
-          <Card className="h-full w-full bg-zinc-200 p-4 dark:bg-zinc-500">
+          <Card className="h-full w-full bg-card p-4">
             <p className="text-sm">{"aipictors.com"}</p>
             <AppCanvas />
           </Card>

--- a/app/_components/paint-canvas.tsx
+++ b/app/_components/paint-canvas.tsx
@@ -492,15 +492,13 @@ const PaintCanvas: React.FC<IProps> = ({
 
   return (
     <section className="relative h-[100%] w-[100%]">
-      <div className="block h-[100%] w-[100%] md:flex">
+      <div className="block h-[100%] w-[100%] text-gray-500 md:flex">
         <div className="mb-1 flex md:flex-col">
           {!isMosaicMode && (
             <Button
-              className={cn(
-                tool === "brush" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-              )}
+              className="mr-2"
               size="icon"
-              variant="ghost"
+              variant={tool === "lasso" ? "secondary" : "ghost"}
               onClick={() => setTool("brush")}
             >
               <BrushIcon className="m-auto" />
@@ -508,11 +506,9 @@ const PaintCanvas: React.FC<IProps> = ({
           )}
           {!isMosaicMode && (
             <Button // 2. 投げ縄ボタンを追加
-              className={cn(
-                tool === "lasso" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-              )}
+              className="mr-2"
               size="icon"
-              variant="ghost"
+              variant={tool === "lasso" ? "secondary" : "ghost"}
               onClick={() => setTool("lasso")}
             >
               <LassoIcon className="m-auto" />
@@ -520,13 +516,9 @@ const PaintCanvas: React.FC<IProps> = ({
           )}
           {isMosaicMode && (
             <Button // 2. 投げ縄ボタンを追加
-              className={cn(
-                tool === "lasso-mosaic"
-                  ? "mr-2 bg-gray-200 dark:bg-gray-800"
-                  : "mr-2",
-              )}
+              className="mr-2"
               size="icon"
-              variant="ghost"
+              variant={tool === "lasso-mosaic" ? "secondary" : "ghost"}
               onClick={() => setTool("lasso-mosaic")}
             >
               <LassoIcon className="m-auto" />
@@ -534,11 +526,9 @@ const PaintCanvas: React.FC<IProps> = ({
           )}
 
           <Button
-            className={cn(
-              tool === "eraser" ? "mr-2 bg-gray-200 dark:bg-gray-800" : "mr-2",
-            )}
+            className="mr-2"
             size="icon"
-            variant="ghost"
+            variant={tool === "eraser" ? "secondary" : "ghost"}
             onClick={() => setTool("eraser")}
           >
             <EraserIcon className="m-auto" />
@@ -634,7 +624,7 @@ const PaintCanvas: React.FC<IProps> = ({
         </div>
         <div
           className={cn(
-            "flex h-[100%] w-full items-center justify-center overflow-hidden border border-gray-300 bg-gray-100 dark:border-gray-600 dark:bg-gray-900",
+            "flex h-[100%] w-full items-center justify-center overflow-hidden border border-gray-500",
           )}
         >
           <div

--- a/app/_components/sort-list-selector.tsx
+++ b/app/_components/sort-list-selector.tsx
@@ -19,7 +19,7 @@ export const SortListSelector = (props: Props) => {
             onKeyUp={item.callback}
             onKeyDown={item.callback}
             onKeyPress={item.callback}
-            className="flex w-full cursor-pointer items-center p-4 transition-all hover:bg-gray-100 dark:hover:bg-gray-800"
+            className="flex w-full cursor-pointer items-center p-4 transition-all hover:bg-card dark:hover:bg-card"
           >
             {props.nowSortType === item.sortType ? (
               <CheckIcon className="mr-2 w-4" />

--- a/app/_components/tag/tag.tsx
+++ b/app/_components/tag/tag.tsx
@@ -15,6 +15,8 @@ export const tagVariants = cva(
           "bg-primary border-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive border-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "bg-background border-border text-foreground hover:bg-primary/90",
       },
       size: {
         sm: "text-xs h-7",

--- a/app/routes/($lang)._main._index/_components/home-notifications-comments-tabs.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-comments-tabs.tsx
@@ -29,7 +29,7 @@ export const HomeNotificationCommentsTabs = () => {
     <>
       <ScrollArea className="relative h-96 overflow-y-auto">
         <Tabs
-          className="sticky top-0 z-10 bg-white pt-1 dark:bg-zinc-900"
+          className="sticky top-0 z-10 bg-popover pt-1 dark:bg-zinc-900"
           defaultValue={defaultTab}
         >
           <div className="border-b">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-award-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-award-item.tsx
@@ -17,7 +17,7 @@ export const HomeNotificationsContentAwardItem = (props: Props) => {
     <>
       <Link
         to={`/posts/${props.workId}`}
-        className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center p-1 transition-all hover:bg-card"
       >
         <>
           <div className="h-12 w-12 overflow-hidden rounded-md">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-commented-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-commented-item.tsx
@@ -34,7 +34,7 @@ export const HomeNotificationsContentCommentedItem = (props: Props) => {
       <div className="flex flex-col space-y-1 border-b p-1">
         <Link
           to={`/posts/${props.workId}`}
-          className="flex items-center rounded-md p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+          className="flex items-center rounded-md p-1 transition-all hover:bg-card"
         >
           <>
             <img

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-followed-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-followed-item.tsx
@@ -19,7 +19,7 @@ export const HomeNotificationsContentFollowedItem = (props: Props) => {
   return (
     <>
       <Link
-        className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center p-1 transition-all hover:bg-card"
         to={`/users/${props.userId}`}
       >
         <img

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-liked-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-liked-item.tsx
@@ -20,7 +20,7 @@ export const HomeNotificationsContentLikedItem = (props: Props) => {
       {props.workId && (
         <Link
           to={`/posts/${props.workId}`}
-          className="flex items-center p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+          className="flex items-center p-1 transition-all hover:bg-card"
         >
           <>
             <div className="h-12 w-12 overflow-hidden rounded-md">

--- a/app/routes/($lang)._main._index/_components/home-notifications-content-reply-item.tsx
+++ b/app/routes/($lang)._main._index/_components/home-notifications-content-reply-item.tsx
@@ -22,7 +22,7 @@ export const HomeNotificationsContentReplyItem = (props: Props) => {
     <>
       <Link
         to={`/posts/${props.workId}`}
-        className="flex items-center border-b p-1 transition-all hover:bg-zinc-100 hover:dark:bg-zinc-900"
+        className="flex items-center border-b p-1 transition-all hover:bg-card"
       >
         <Link to={`/users/${props.ownerUserId}`}>
           <img

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -124,7 +124,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       <DropdownMenuContent>
         <div>
           <div
-            className="relative mb-4 h-16 w-full rounded-md bg-gray-100 p-2 dark:bg-gray-800"
+            className="relative mb-4 h-16 w-full rounded-md bg-card p-2"
             style={{
               backgroundImage: `url(${headerImageUrl})`,
               backgroundSize: "cover",

--- a/app/routes/($lang)._main.new.image/_components/ad-work-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/ad-work-input.tsx
@@ -14,7 +14,7 @@ type Props = {
 export const AdWorkInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">宣伝作品</p>
           <div className="mb-1 items-center text-sm opacity-65">

--- a/app/routes/($lang)._main.new.image/_components/caption-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/caption-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const CaptionInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">
             {props.label ? props.label : "キャプション（任意）"}

--- a/app/routes/($lang)._main.new.image/_components/category-editable-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/category-editable-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const CategoryEditableInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">タグの編集許可</p>
           <div className="flex items-center space-x-2">

--- a/app/routes/($lang)._main.new.image/_components/comments-editable-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/comments-editable-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const CommentsEditableInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">コメント許可</p>
           <div className="flex items-center space-x-2">

--- a/app/routes/($lang)._main.new.image/_components/date-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/date-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const DateInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">予約投稿</p>
           <div className="block md:flex">

--- a/app/routes/($lang)._main.new.image/_components/event-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/event-input.tsx
@@ -43,7 +43,7 @@ export const EventInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{"イベント"}</p>
           <div className="items-center">

--- a/app/routes/($lang)._main.new.image/_components/generation-params-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/generation-params-input.tsx
@@ -32,7 +32,7 @@ export const GenerationParamsInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">生成情報</p>
           <p className="mb-1 text-xs">プロンプト</p>

--- a/app/routes/($lang)._main.new.image/_components/model-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/model-input.tsx
@@ -32,7 +32,7 @@ export const ModelInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">使用AI</p>
           <Select

--- a/app/routes/($lang)._main.new.image/_components/new-image-form.tsx
+++ b/app/routes/($lang)._main.new.image/_components/new-image-form.tsx
@@ -628,7 +628,7 @@ export const NewImageForm = () => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-background">
           <div
             // biome-ignore lint/nursery/useSortedClasses: <explanation>
             className={`relative items-center bg-gray-800 ${
@@ -891,7 +891,7 @@ export const NewImageForm = () => {
             />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2">
           <Button className="w-full" type="submit" onClick={onPost}>
             投稿
           </Button>

--- a/app/routes/($lang)._main.new.image/_components/rating-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/rating-input.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const RatingInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">年齢制限</p>
           <RadioGroup

--- a/app/routes/($lang)._main.new.image/_components/related-link-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/related-link-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const RelatedLinkInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{"関連リンク"}</p>
           <Input

--- a/app/routes/($lang)._main.new.image/_components/series-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/series-input.tsx
@@ -21,7 +21,7 @@ type Props = {
 export const AlbumInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">シリーズ</p>
           <Select

--- a/app/routes/($lang)._main.new.image/_components/success-created-work-dialog.tsx
+++ b/app/routes/($lang)._main.new.image/_components/success-created-work-dialog.tsx
@@ -83,7 +83,7 @@ export const SuccessCreatedWorkDialog = (props: Props) => {
           <div className="relative h-40 w-full">
             <div
               id="confetti-container"
-              className="relative h-40 w-full overflow-hidden bg-zinc-100 dark:bg-zinc-900"
+              className="relative h-40 w-full overflow-hidden bg-secondary dark:bg-zinc-900"
             />
             {props.createdAt > new Date().getTime() ? (
               <Link to={"/dashboard/posts"}>

--- a/app/routes/($lang)._main.new.image/_components/tag-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/tag-input.tsx
@@ -19,7 +19,7 @@ export const TagsInput = (props: Props) => {
 
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mb-1 font-bold text-sm">{`タグ (${props.tags.length}/10)`}</p>
           <TagInput
@@ -33,6 +33,7 @@ export const TagsInput = (props: Props) => {
             maxTags={10}
             maxLength={160}
             className="sm:min-w-[450px]"
+            variant="outline"
             setTags={(newTags) => {
               props.setTags(newTags as [Tag, ...Tag[]])
               console.log(newTags)
@@ -60,7 +61,7 @@ export const TagsInput = (props: Props) => {
                 <Button
                   key={tag.id}
                   className="mr-2 mb-2 w-auto"
-                  variant={"secondary"}
+                  variant={"outline"}
                   onClick={() => {
                     if (props.tags.length >= 10) {
                       return

--- a/app/routes/($lang)._main.new.image/_components/taste-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/taste-input.tsx
@@ -18,7 +18,7 @@ type Props = {
 export const TasteInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">テイスト</p>
           <Select

--- a/app/routes/($lang)._main.new.image/_components/theme-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/theme-input.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const ThemeInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">お題参加</p>
           {props.isLoading ? (

--- a/app/routes/($lang)._main.new.image/_components/title-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/title-input.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const TitleInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="flex flex-col">
           <p className="mb-1 font-bold text-sm">
             {props.label ? props.label : "タイトル（必須）"}

--- a/app/routes/($lang)._main.new.image/_components/view-input.tsx
+++ b/app/routes/($lang)._main.new.image/_components/view-input.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const ViewInput = (props: Props) => {
   return (
     <>
-      <div className="mt-2 mb-2 space-y-2 rounded-md bg-white pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
+      <div className="mt-2 mb-2 space-y-2 rounded-md bg-secondary pt-1 pr-2 pb-4 pl-2 dark:bg-zinc-900">
         <div className="mt-2 flex flex-col">
           <p className="mt-1 mb-1 font-bold text-sm">公開モード</p>
           <RadioGroup

--- a/app/routes/($lang)._main.new.text/_components/new-text-form.tsx
+++ b/app/routes/($lang)._main.new.text/_components/new-text-form.tsx
@@ -638,7 +638,7 @@ export const NewTextForm = () => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-card">
           <CropImageField
             isHidePreviewImage={thumbnailBase64 === ""}
             cropWidth={400}
@@ -851,7 +851,7 @@ export const NewTextForm = () => {
             />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2">
           <Button className="w-full" type="submit" onClick={onPost}>
             投稿
           </Button>

--- a/app/routes/($lang)._main.posts.$post.edit._index/_components/edit-image-form.tsx
+++ b/app/routes/($lang)._main.posts.$post.edit._index/_components/edit-image-form.tsx
@@ -734,7 +734,7 @@ export const EditImageForm = (props: Props) => {
   return (
     <>
       <div className="relative w-[100%]">
-        <div className="mb-4 bg-gray-100 dark:bg-black">
+        <div className="mb-4 bg-card">
           <div
             // biome-ignore lint/nursery/useSortedClasses: <explanation>
             className={`relative items-center pb-2 bg-gray-800 ${
@@ -1001,7 +1001,7 @@ export const EditImageForm = (props: Props) => {
             <AdWorkInput isChecked={isAd} onChange={setIsAd} />
           </ScrollArea>
         </div>
-        <div className="sticky bottom-0 bg-white pb-2 dark:bg-black">
+        <div className="sticky bottom-0 bg-background pb-2">
           <Button className="w-full" type="submit" onClick={onPost}>
             更新
           </Button>

--- a/app/routes/($lang)._main.posts.$post/_components/work-html-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-html-view.tsx
@@ -5,7 +5,7 @@ type Props = {
 
 export const WorkHtmlView = ({ thumbnailUrl, html }: Props) => {
   return (
-    <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+    <div className="relative m-0 bg-card">
       <img
         src={thumbnailUrl}
         alt="Thumbnail"

--- a/app/routes/($lang)._main.posts.$post/_components/work-image-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-image-view.tsx
@@ -48,7 +48,7 @@ export const WorkImageView = ({ workImageURL, subWorkImageURLs }: Props) => {
 
   if (workImageURL) {
     return (
-      <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+      <div className="relative m-0 bg-card">
         <ImagesPreview
           currentIndex={0}
           setCurrentIndex={() => {}}

--- a/app/routes/($lang)._main.posts.$post/_components/work-video-view.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-video-view.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const WorkVideoView = ({ videoUrl }: Props) => {
   return (
-    <div className="relative m-0 bg-gray-100 dark:bg-zinc-950">
+    <div className="relative m-0 bg-card">
       <video
         controls
         className="m-auto h-auto w-auto object-contain xl:max-h-[80vh]"

--- a/app/routes/($lang)._main.rankings._index/_components/ranking-header.tsx
+++ b/app/routes/($lang)._main.rankings._index/_components/ranking-header.tsx
@@ -58,7 +58,7 @@ export const RankingHeader = (props: Props) => {
                 type="number"
                 value={year}
                 onChange={handleYearChange}
-                className="w-16 text-center"
+                className="w-16 border-[1px] border-foreground border-solid bg-background text-center text-foreground"
                 min="2000"
                 max="2100"
               />
@@ -67,7 +67,7 @@ export const RankingHeader = (props: Props) => {
                 type="number"
                 value={month}
                 onChange={handleMonthChange}
-                className="w-12 text-center"
+                className="w-12 border-[1px] border-foreground border-solid bg-background text-center text-foreground"
                 min="1"
                 max="12"
               />
@@ -78,7 +78,7 @@ export const RankingHeader = (props: Props) => {
                     type="number"
                     value={day}
                     onChange={handleDayChange}
-                    className="w-12 text-center"
+                    className="w-12 border-[1px] border-foreground border-solid bg-background text-center text-foreground"
                     min="1"
                     max="31"
                   />

--- a/app/routes/($lang)._main.users.$user/_components/user-home-main.tsx
+++ b/app/routes/($lang)._main.users.$user/_components/user-home-main.tsx
@@ -42,7 +42,7 @@ export const UserHomeMain = (props: Props) => {
   const isFollow = userInfo?.user?.isFollowee ?? false
 
   return (
-    <div className="relative m-auto h-64 w-full bg-neutral-100 md:h-24 dark:bg-neutral-900">
+    <div className="relative m-auto h-64 w-full bg-card md:h-24">
       <div className="absolute top-8 right-0 hidden md:block">
         <div className="flex items-center space-x-2">
           <FollowButton

--- a/app/routes/($lang).dashboard._index/_components/dashboard-home-content-container.tsx
+++ b/app/routes/($lang).dashboard._index/_components/dashboard-home-content-container.tsx
@@ -9,8 +9,8 @@ type Props = {
 export const DashboardHomeContentContainer = (props: Props) => {
   return (
     <>
-      <div className="h-auto rounded-md bg-zinc-50 md:h-[640px] dark:bg-zinc-700">
-        <div className="w-full rounded-t-md bg-zinc-100 p-4 font-bold dark:bg-zinc-800">
+      <div className="h-auto rounded-md bg-card md:h-[640px]">
+        <div className="w-full rounded-t-md bg-secondary p-4 font-bold">
           {props.title}
         </div>
         {props.children}

--- a/app/routes/($lang).dashboard._index/_components/works-settings-contents.tsx
+++ b/app/routes/($lang).dashboard._index/_components/works-settings-contents.tsx
@@ -22,7 +22,7 @@ export const WorksSettingContents = (props: Props) => {
           isActive={props.workTabType === "WORK"}
         >
           {"作品"}
-          <div className="m-2 min-w-8 rounded-full bg-zinc-400 pr-1 pl-1 text-white dark:bg-zinc-600">
+          <div className="m-2 min-w-8 rounded-full bg-accent pr-1 pl-1 text-accent-foreground">
             {props.sumWorksCount}
           </div>
         </RoundedLightButton>
@@ -33,7 +33,7 @@ export const WorksSettingContents = (props: Props) => {
           isActive={props.workTabType === "ALBUM"}
         >
           {"シリーズ"}
-          <div className="m-2 min-w-8 rounded-full bg-zinc-400 pr-1 pl-1 text-white dark:bg-zinc-600">
+          <div className="m-2 min-w-8 rounded-full bg-accent pr-1 pl-1 text-accent-foreground">
             {props.sumAlbumsCount}
           </div>
         </RoundedLightButton>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -9,24 +9,24 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 20 14.3% 4.1%;
-    --card: 0 0% 100%;
-    --card-foreground: 20 14.3% 4.1%;
+    --foreground: 20 14% 4%;
+    --card: 0 0% 96%;
+    --card-foreground: 20 14% 4%;
     --popover: 0 0% 100%;
-    --popover-foreground: 20 14.3% 4.1%;
-    --primary: 24 9.8% 10%;
-    --primary-foreground: 60 9.1% 97.8%;
-    --secondary: 60 4.8% 95.9%;
-    --secondary-foreground: 24 9.8% 10%;
-    --muted: 60 4.8% 95.9%;
-    --muted-foreground: 25 5.3% 44.7%;
-    --accent: 60 4.8% 95.9%;
-    --accent-foreground: 24 9.8% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 60 9.1% 97.8%;
-    --border: 20 5.9% 82%;
-    --input: 20 5.9% 90%;
-    --ring: 20 14.3% 4.1%;
+    --popover-foreground: 20 14% 4%;
+    --primary: 24 10% 10%;
+    --primary-foreground: 60 9% 98%;
+    --secondary: 60 5% 93%;
+    --secondary-foreground: 24 10% 10%;
+    --muted: 60 5% 96%;
+    --muted-foreground: 25 5% 44%;
+    --accent: 60 5% 96%;
+    --accent-foreground: 24 10% 10%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 60 9% 98%;
+    --border: 20 6% 82%;
+    --input: 20 6% 90%;
+    --ring: 20 14% 4%;
     --monotone-50: 0 0% 95%;
     --monotone-100: 0 0% 90%;
     --monotone-200: 0 0% 80%;
@@ -41,24 +41,24 @@
   }
 
   .dark {
-    --background: 20 14.3% 4.1%;
-    --foreground: 60 9.1% 97.8%;
-    --card: 20 14.3% 4.1%;
-    --card-foreground: 60 9.1% 97.8%;
-    --popover: 20 14.3% 4.1%;
-    --popover-foreground: 60 9.1% 97.8%;
-    --primary: 60 9.1% 97.8%;
-    --primary-foreground: 24 9.8% 10%;
-    --secondary: 12 6.5% 15.1%;
-    --secondary-foreground: 60 9.1% 97.8%;
+    --background: 20 14% 4%;
+    --foreground: 60 9% 98%;
+    --card: 20 14% 8%;
+    --card-foreground: 60 9% 98%;
+    --popover: 20 14% 4.1%;
+    --popover-foreground: 60 9% 98%;
+    --primary: 60 9% 98%;
+    --primary-foreground: 24 10% 10%;
+    --secondary: 12 6.5% 15%;
+    --secondary-foreground: 60 9% 98%;
     --muted: 12 6.5% 15.1%;
-    --muted-foreground: 24 5.4% 63.9%;
-    --accent: 12 6.5% 15.1%;
-    --accent-foreground: 60 9.1% 97.8%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 60 9.1% 97.8%;
-    --border: 12 6.5% 24.0%;
-    --input: 12 6.5% 15.1%;
+    --muted-foreground: 24 5% 64%;
+    --accent: 12 10% 20%;
+    --accent-foreground: 60 9% 98%;
+    --destructive: 0 63% 30%;
+    --destructive-foreground: 60 9% 98%;
+    --border: 12 6% 24%;
+    --input: 12 6% 15%;
     --monotone-50: 0 0% 5%;
     --monotone-100: 0 0% 10%; 
     --monotone-200: 0 0% 20%; 
@@ -114,11 +114,11 @@
     --popover-foreground: 202 0% 100%;
     --primary: 202 0% 76%;
     --primary-foreground: 0 0% 0%;
-    --secondary: 202 10% 20%;
+    --secondary: 202 20% 20%;
     --secondary-foreground: 0 0% 100%;
     --muted: 164 10% 25%;
     --muted-foreground: 202 0% 65%;
-    --accent: 164 10% 25%;
+    --accent: 164 20% 25%;
     --accent-foreground: 202 0% 95%;
     --destructive: 0 50% 50%;
     --destructive-foreground: 202 0% 100%;
@@ -177,7 +177,7 @@
     --card-foreground: 0 5% 90%;
     --popover: 0 50% 5%;
     --popover-foreground: 0 5% 90%;
-    --primary: 0 95% 50%;
+    --primary: 0 90% 40%;
     --primary-foreground: 0 0% 100%;
     --secondary: 0 30% 20%;
     --secondary-foreground: 0 0% 100%;
@@ -344,7 +344,7 @@
     --popover-foreground: 146 100% 10%;
     --primary: 146 93% 24%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 146 30% 82%;
+    --secondary: 146 50% 75%;
     --secondary-foreground: 0 0% 0%;
     --muted: 108 30% 85%;
     --muted-foreground: 146 5% 40%;
@@ -371,11 +371,11 @@
   .green-dark {
     --background: 146 50% 10%;
     --foreground: 146 5% 90%;
-    --card: 146 50% 10%;
+    --card: 146 50% 13%;
     --card-foreground: 146 5% 90%;
     --popover: 146 50% 5%;
     --popover-foreground: 146 5% 90%;
-    --primary: 146 93% 24%;
+    --primary: 146 93% 35%;
     --primary-foreground: 0 0% 100%;
     --secondary: 146 30% 20%;
     --secondary-foreground: 0 0% 100%;
@@ -443,7 +443,7 @@
     --popover-foreground: 194 5% 90%;
     --primary: 194 100% 60%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 194 30% 10%;
+    --secondary: 194 30% 13%;
     --secondary-foreground: 0 0% 100%;
     --muted: 156 30% 15%;
     --muted-foreground: 194 5% 60%;
@@ -474,7 +474,7 @@
     --card-foreground: 61 5% 15%;
     --popover: 61 100% 95%;
     --popover-foreground: 61 100% 10%;
-    --primary: 61 93% 24%;
+    --primary: 61 93% 40%;
     --primary-foreground: 0 0% 100%;
     --secondary: 61 30% 82%;
     --secondary-foreground: 0 0% 0%;
@@ -507,7 +507,7 @@
     --card-foreground: 61 5% 90%;
     --popover: 61 50% 5%;
     --popover-foreground: 61 5% 90%;
-    --primary: 61 93% 24%;
+    --primary: 61 93% 40%;
     --primary-foreground: 0 0% 100%;
     --secondary: 61 30% 20%;
     --secondary-foreground: 0 0% 100%;
@@ -573,7 +573,7 @@
     --card-foreground: 288 5% 90%;
     --popover: 288 50% 5%;
     --popover-foreground: 288 5% 90%;
-    --primary: 288 93% 24%;
+    --primary: 288 93% 50%;
     --primary-foreground: 0 0% 100%;
     --secondary: 288 30% 20%;
     --secondary-foreground: 0 0% 100%;


### PR DESCRIPTION
・カラーテーマ rev2 part4 monotoneの代わりに、card、primary、secondaryなどを使用する
monotoneを使わない版です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - `RoundedLightButton`コンポーネントが`isActive`プロパティによってスタイルを変更するように更新されました。
  - 多くのコンポーネントで背景色およびテキスト色のクラスが更新され、より一貫したデザインに改善。
  - `PaintCanvas`コンポーネントのボタンスタイリングが簡素化され、可読性が向上しました。

- **スタイル**
  - 全体的なCSSカスタムプロパティの調整により、各カラースキーム（`base`、`dark`、`light`、`green-dark`）の背景、前景、カードスタイル等が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->