### PR TITLE
カラーテーマ rev3

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -87,30 +87,30 @@ export function Layout(props: Props) {
         style={{ margin: "0 !important" }}
       >
         <ThemeProvider
-          attribute={"class"}
           defaultTheme={"system"}
           themes={[
             "system",
             "dark",
             "light",
-            "gray-light",
-            "gray-dark",
-            "red-light",
-            "red-dark",
-            "pink-light",
-            "pink-dark",
-            "orange-light",
-            "orange-dark",
-            "green-light",
-            "green-dark",
-            "blue-light",
-            "blue-dark",
-            "yellow-light",
-            "yellow-dark",
-            "violet-light",
-            "violet-dark",
+            "light-gray",
+            "dark-gray",
+            "light-red",
+            "dark-red",
+            "light-pink",
+            "dark-pink",
+            "light-orange",
+            "dark-orange",
+            "light-green",
+            "dark-green",
+            "light-blue",
+            "dark-blue",
+            "light-yellow",
+            "dark-yellow",
+            "light-violet",
+            "dark-violet",
           ]}
           enableSystem
+          enableColorScheme
           disableTransitionOnChange
         >
           <ContextProviders>

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -86,19 +86,19 @@ export const HomeUserNavigationMenu = (props: Props) => {
       setTheme(newMode)
       return
     }
-    // テーマ適用中→"blue-light"、"blue-dark"等同色でのダーク、ライト切り替え
-    const prefix = theme?.replace(/\-(light|dark)/, "-")
-    const colorPrefix = prefix ?? ""
-    setTheme(colorPrefix + newMode)
+    // テーマ適用中→"light-blue-"、"dark-blue"等同色でのダーク、ライト切り替え
+    const suffix = theme?.replace(/(light|dark)\-/, "-")
+    const colorSuffix = suffix ?? ""
+    setTheme(newMode + colorSuffix)
   }
   const setMode = (theme: string) => {
     if (theme === "system" || theme === "light" || theme === "dark") {
       return theme
     }
-    if (theme.endsWith("-light")) {
+    if (theme.startsWith("light-")) {
       return "light"
     }
-    if (theme.endsWith("-dark")) {
+    if (theme.startsWith("dark-")) {
       return "dark"
     }
     return "system"

--- a/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/_components/home-user-navigation-menu.tsx
@@ -86,7 +86,7 @@ export const HomeUserNavigationMenu = (props: Props) => {
       setTheme(newMode)
       return
     }
-    // テーマ適用中→"light-blue-"、"dark-blue"等同色でのダーク、ライト切り替え
+    // テーマ適用中→"light-blue"、"dark-blue"等同色でのダーク、ライト切り替え
     const suffix = theme?.replace(/(light|dark)\-/, "-")
     const colorSuffix = suffix ?? ""
     setTheme(newMode + colorSuffix)

--- a/app/routes/($lang).settings.color/route.tsx
+++ b/app/routes/($lang).settings.color/route.tsx
@@ -39,16 +39,18 @@ export default function SettingColor() {
       setTheme(mode)
       return
     }
-    setTheme(`${color}-${mode}`)
+    const themeName = `${mode}-${color}`
+    console.log(themeName)
+    setTheme(themeName)
   }
   const setMode = (theme: string) => {
     if (theme === "system" || theme === "light" || theme === "dark") {
       return theme
     }
-    if (theme.endsWith("-light")) {
+    if (theme.startsWith("light-")) {
       return "light"
     }
-    if (theme.endsWith("-dark")) {
+    if (theme.startsWith("dark-")) {
       return "dark"
     }
     return "system"
@@ -58,8 +60,9 @@ export default function SettingColor() {
     if (theme === "system" || theme === "light" || theme === "dark") {
       return "none"
     }
-    const prefix = theme.replace(/\-(light|dark)/, "")
-    return prefix ?? "none"
+    const suffix = theme.replace(/(light|dark)\-/, "")
+    console.log(`suffix: ${suffix}`)
+    return suffix ?? "none"
   }
   const colorSchema = setColorSchema(theme ? theme : "system")
   const themeRadio = (value: string, label: string) => {

--- a/app/routes/($lang).settings.color/route.tsx
+++ b/app/routes/($lang).settings.color/route.tsx
@@ -40,7 +40,6 @@ export default function SettingColor() {
       return
     }
     const themeName = `${mode}-${color}`
-    console.log(themeName)
     setTheme(themeName)
   }
   const setMode = (theme: string) => {
@@ -61,7 +60,6 @@ export default function SettingColor() {
       return "none"
     }
     const suffix = theme.replace(/(light|dark)\-/, "")
-    console.log(`suffix: ${suffix}`)
     return suffix ?? "none"
   }
   const colorSchema = setColorSchema(theme ? theme : "system")

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -40,7 +40,7 @@
     --radius: 0.5rem;
   }
 
-  .dark {
+  html[data-theme='dark'] {
     --background: 20 14.3% 4.1%;
     --foreground: 60 9.1% 97.8%;
     --card: 20 14.3% 4.1%;
@@ -72,7 +72,7 @@
     --ring: 24 5.7% 82.9%;
   }
 
-  .gray-light {
+  html[data-theme='light-gray'] {
     --background: 192 0% 95%;
     --foreground: 192 0% 0%;
     --card: 192 0% 90%;
@@ -105,7 +105,7 @@
     --radius: 0.5rem;
   }
 
-  .gray-dark  {
+  html[data-theme='dark-gray'] {
     --background: 202 10% 10%;
     --foreground: 202 0% 100%;
     --card: 202 0% 10%;
@@ -137,7 +137,7 @@
     --monotone-900: 0 0% 90%; 
     --radius: 0.5rem;
   }
-  .red-light {
+html[data-theme='light-red'] {
     --background: 0 100% 95%;
     --foreground: 0 5% 10%;
     --card: 0 50% 90%;
@@ -170,7 +170,7 @@
     --radius: 0.5rem;
   }
 
-  .red-dark {
+  html[data-theme='dark-red'] {
     --background: 0 50% 10%;
     --foreground: 0 5% 90%;
     --card: 0 50% 10%;
@@ -203,7 +203,7 @@
     --radius: 0.5rem;
   }
 
-  .pink-light {
+  html[data-theme='light-pink'] {
     --background: 310 100% 97%;
     --foreground: 310 5% 10%;
     --card: 310 50% 92%;
@@ -236,7 +236,7 @@
     --radius: 0.5rem;
   }
 
-  .pink-dark {
+  html[data-theme='dark-pink'] {
     --background: 310 50% 15%;
     --foreground: 310 100% 95%;
     --card: 310 50% 20%;
@@ -269,8 +269,8 @@
     --radius: 0.5rem;
   }
 
-  .orange-light {
-    --background: 34 100% 95%;
+  html[data-theme='light-orange'] {
+      --background: 34 100% 95%;
     --foreground: 34 5% 10%;
     --card: 34 50% 90%;
     --card-foreground: 34 5% 15%;
@@ -302,8 +302,8 @@
     --radius: 0.5rem;
 }
 
-  .orange-dark {
-    --background: 34 50% 10%;
+  html[data-theme='dark-orange'] {
+      --background: 34 50% 10%;
     --foreground: 34 5% 90%;
     --card: 34 50% 10%;
     --card-foreground: 34 5% 90%;
@@ -335,7 +335,7 @@
     --radius: 0.5rem;
   }
 
-  .green-light {
+  html[data-theme='light-green'] {
     --background: 146 100% 95%;
     --foreground: 146 5% 10%;
     --card: 146 50% 90%;
@@ -368,8 +368,8 @@
     --radius: 0.5rem;
   }
 
-  .green-dark {
-    --background: 146 50% 10%;
+  html[data-theme='dark-green'] {
+      --background: 146 50% 10%;
     --foreground: 146 5% 90%;
     --card: 146 50% 10%;
     --card-foreground: 146 5% 90%;
@@ -401,7 +401,7 @@
     --radius: 0.5rem;
   }
 
-  .blue-light {
+  html[data-theme='light-blue'] {
     --background: 194 100% 95%;
     --foreground: 194 5% 0%;
     --card: 194 50% 90%;
@@ -434,8 +434,8 @@
     --radius: 0.5rem;
   }
 
-  .blue-dark {
-    --background: 194 50% 5%;
+  html[data-theme='dark-blue'] {
+      --background: 194 50% 5%;
     --foreground: 194 5% 90%;
     --card: 194 50% 0%;
     --card-foreground: 194 5% 90%;
@@ -467,8 +467,8 @@
     --radius: 0.5rem;
   }
 
-  .yellow-light {
-    --background: 61 100% 95%;
+  html[data-theme='light-yellow'] {
+      --background: 61 100% 95%;
     --foreground: 61 5% 10%;
     --card: 61 50% 90%;
     --card-foreground: 61 5% 15%;
@@ -500,8 +500,8 @@
     --radius: 0.5rem;
   }
 
-  .yellow-dark {
-    --background: 61 50% 10%;
+  html[data-theme='dark-yellow'] {
+      --background: 61 50% 10%;
     --foreground: 61 5% 90%;
     --card: 61 50% 10%;
     --card-foreground: 61 5% 90%;
@@ -533,8 +533,8 @@
     --radius: 0.5rem;
   }
 
-  .violet-light {
-    --background: 288 100% 95%;
+  html[data-theme='light-violet'] {
+      --background: 288 100% 95%;
     --foreground: 288 5% 10%;
     --card: 288 50% 90%;
     --card-foreground: 288 5% 15%;
@@ -566,8 +566,8 @@
     --radius: 0.5rem;
   }
 
-  .violet-dark {
-    --background: 288 50% 10%;
+  html[data-theme='dark-violet'] {
+      --background: 288 50% 10%;
     --foreground: 288 5% 90%;
     --card: 288 50% 10%;
     --card-foreground: 288 5% 90%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,7 +4,7 @@ import { fontFamily } from "tailwindcss/defaultTheme"
 
 export default {
   plugins: [animatePlugin],
-  darkMode: ["class"],
+  darkMode: ["class", '[data-theme^="dark-"]'],
   content: [".storybook/**/*.tsx", "app/**/*.tsx"],
   theme: {
     /**


### PR DESCRIPTION
- dark-gray、dark-blueなどにclassName="dark:bg-card"などが適用できるように
- lightおよびdarkの色は元の色のままにする

monotone不要、lightおよびdarkは尊重されます。
"bg-gray-100 dark:bg-gray-900"などもそれぞれのdark系light系に反映されます。
前のパッチPRは"dark"以外のdark系の色が通常色(白飛び)になってしまうために、monotoneハックやbg-backgroundなどへの書き換えが必要とされていましたが、これでは基本的に不要です。
ただし例外があって、カルーセルの半透明のグラデーションは背景色に合わせたほうが良いと思います（がこのPRではそのままです）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - テーマの改良：より説明的な名前と新しいテーマ「dark-gray」を追加し、テーマ設定の構造を改善しました。
  - ダイナミックテーマ：`data-theme`属性に基づくスタイル適用に変更し、動的なテーマ切り替えを可能にしました。

- **バグ修正**
  - ダークモードとライトモードの切り替えの一貫性を改善しました。

- **スタイル**
  - テーマ関連のクラスセレクターを属性セレクターに置き換え、テーマ設定の柔軟性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->