### PR TITLE
アラートの見た目を変更する

### DIFF
--- a/app/_components/construction-alert.tsx
+++ b/app/_components/construction-alert.tsx
@@ -1,35 +1,57 @@
 import { Alert, AlertDescription, AlertTitle } from "@/_components/ui/alert"
+import { Button } from "@/_components/ui/button"
 import { Link } from "@remix-run/react"
 
 type Props = {
-  type: "BUG" | "WARNING" | "INFO"
-  title: string
-  message?: string
-  fallbackURL: string
-  date?: string
+  /**
+   * 一旦は不要
+   * @deprecated
+   */
+  type?: "BUG" | "WARNING" | "INFO" | "CONSTRUCTION"
+  /**
+   * メッセージ（任意）
+   */
+  message: string | null
+  /**
+   * 旧バージョンのURL
+   * 値がnullの場合はhttps://www.aipictors.comに遷移する
+   */
+  fallbackURL: string | null
+  deadline?: string
 }
 
 export const ConstructionAlert: React.FC<Props> = (props: Props) => {
+  const alertTitle = () => {
+    if (props.type === "BUG") {
+      return "不具合を修正中です。"
+    }
+    if (props.type === "WARNING") {
+      return "このページは現在開発中です。"
+    }
+    return "このページは現在開発中です。"
+  }
+
   return (
-    <Link to={props.fallbackURL}>
-      <Alert className="border-2">
-        <AlertTitle>
-          {props.type === "BUG"
-            ? "バグ"
-            : props.type === "WARNING"
-              ? "ご注意"
-              : "情報"}
-        </AlertTitle>
-        <AlertDescription>
-          {`${props.title}`}
-          {props.message
-            ? `: ${props.message}`
-            : "元のバージョンはこちらをクリックしてください。"}
-          {props.date &&
-            props.type === "WARNING" &&
-            `(${props.date}までに完了予定です。)`}
-        </AlertDescription>
-      </Alert>
-    </Link>
+    <Alert className="space-y-2 border-none bg-primary text-white">
+      <AlertTitle>{alertTitle()}</AlertTitle>
+      <div className="flex flex-col justify-between gap-2 md:flex-row">
+        {props.message && <AlertDescription>{props.message}</AlertDescription>}
+        <div className="flex justify-end gap-2">
+          <Link
+            to={props.fallbackURL ?? "https://www.aipictors.com"}
+            className="flex-1 md:flex-auto"
+          >
+            <Button size={"sm"} variant={"secondary"} className="w-full">
+              {"旧バージョンへ"}
+            </Button>
+          </Link>
+          <Link to={"https://discord.com/invite/aipictors"}>
+            <Button size={"sm"} variant={"secondary"}>
+              {"不具合報告"}
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </Alert>
   )
 }

--- a/app/routes/($lang)._main._index/route.tsx
+++ b/app/routes/($lang)._main._index/route.tsx
@@ -101,9 +101,9 @@ export default function Index() {
     <AppPage>
       <ConstructionAlert
         type="WARNING"
-        title="このページは現在開発中です。不具合が起きる可能性があります。"
+        message="不具合が起きる可能性があります。"
         fallbackURL="https://www.aipictors.com/"
-        date={"2024-07-30"}
+        deadline={"2024-07-30"}
       />
       <HomeBanners adWorks={data.adWorks} />
       {data && (

--- a/app/routes/($lang)._main.new.image/route.tsx
+++ b/app/routes/($lang)._main.new.image/route.tsx
@@ -11,7 +11,7 @@ export default function NewImage() {
     >
       <ConstructionAlert
         type="WARNING"
-        title="試験的にリニューアル版を運用中です。"
+        message="試験的にリニューアル版を運用中です。"
         fallbackURL="https://www.aipictors.com/post"
       />
       <NewImageForm />

--- a/app/routes/($lang)._main.posts.$post.edit._index/route.tsx
+++ b/app/routes/($lang)._main.posts.$post.edit._index/route.tsx
@@ -20,7 +20,7 @@ export default function EditImage() {
     >
       <ConstructionAlert
         type="WARNING"
-        title="試験的にリニューアル版を運用中です。"
+        message="試験的にリニューアル版を運用中です。"
         fallbackURL={`https://www.aipictors.com/edit-work/?id=${params.post}`}
       />
 

--- a/app/routes/($lang)._main.posts.$post/_components/work-article.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-article.tsx
@@ -44,9 +44,9 @@ export const WorkArticle = (props: Props) => {
     <article className="flex flex-col space-y-2">
       <ConstructionAlert
         type="WARNING"
-        title="このページは現在開発中です。不具合が起きる可能性があります。"
+        message="このページは現在開発中です。不具合が起きる可能性があります。"
         fallbackURL={`https://www.aipictors.com/works/${props.work.id}`}
-        date={"2024-07-30"}
+        deadline={"2024-07-30"}
       />
       <PostAccessTypeBanner postAccessType={props.work.accessType} />
       {props.work.type === "WORK" && (

--- a/app/routes/($lang)._main.users.$user/route.tsx
+++ b/app/routes/($lang)._main.users.$user/route.tsx
@@ -75,9 +75,9 @@ export default function UserLayout() {
         <Suspense>
           <ConstructionAlert
             type="WARNING"
-            title="このページは現在開発中です。不具合が起きる可能性があります。"
+            message="このページは現在開発中です。不具合が起きる可能性があります。"
             fallbackURL={`https://www.aipictors.com/users/${params.user}`}
-            date={"2024-07-30"}
+            deadline={"2024-07-30"}
           />
           <div className="flex w-full flex-col justify-center">
             <div className="relative">


### PR DESCRIPTION
少し目立つようになった。色はボタンと同じ bg-primary を使用している。

デスクトップ|モバイル
:--|:--
![スクリーンショット 2024-07-15 23 15 32](https://github.com/user-attachments/assets/ce4a66e0-8b32-44a7-9731-ee2d68bee0d0)|![スクリーンショット 2024-07-15 23 15 43](https://github.com/user-attachments/assets/fbbeac56-f802-4956-bc7d-00e56de90d11)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アラート機能に新しい `CONSTRUCTION` タイプを追加しました。

- **変更点**
  - `ConstructionAlert`コンポーネントの`type`プロパティがオプショナルとなり、新しい`CONSTRUCTION`タイプも含まれました。
  - `message`および`fallbackURL`プロパティが`string`または`null`で設定できるようになりました。
  - `deadline`プロパティを追加しました。

- **その他**
  - `title`プロパティを`message`に変更し、`date`プロパティを`deadline`に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->