### PR TITLE
[add] 作品のタグ編集機能を追加する

### DIFF
--- a/app/routes/($lang)._main.posts.$post/_components/work-article-tags.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-article-tags.tsx
@@ -1,44 +1,59 @@
-import { ToggleContent } from "@/_components/toggle-content"
+import type { Tag } from "@/_components/tag/tag-input"
 import { Button } from "@/_components/ui/button"
+import { WorkTagInput } from "@/routes/($lang)._main.posts.$post/_components/work-tag-input"
 import { Link } from "@remix-run/react"
 import { PlusIcon } from "lucide-react"
-import type React from "react"
-
-type Tag = {
-  id: string
-  text: string
-}
+import React from "react"
 
 type WorkArticleTagProps = {
   tagNames: string[]
   isEditable?: boolean
+  postId: string
 }
 
 export const WorkArticleTags: React.FC<WorkArticleTagProps> = ({
   tagNames,
   isEditable = false,
+  postId,
 }) => {
+  const [isOpenEdit, setIsOpenEdit] = React.useState(false)
+
+  const [tags, setTags] = React.useState<Tag[]>([
+    ...tagNames.map((tagName) => ({ id: tagName, text: tagName })),
+  ])
+
   return (
-    <div className="flex flex-row flex-wrap">
-      {tagNames.map((tagName) => (
-        <Link
-          to={`https://www.aipictors.com/search/?tag=${tagName}`}
-          key={tagName}
-        >
-          <Button variant={"link"}>{`#${tagName}`}</Button>
-        </Link>
-      ))}
-      {isEditable && (
-        <ToggleContent
-          trigger={
-            <Button className="h-8 w-8" size={"icon"} variant={"ghost"}>
-              <PlusIcon />
-            </Button>
-          }
-        >
-          <div>{"メンテナンス中"}</div>
-        </ToggleContent>
+    <>
+      <div className="flex flex-row flex-wrap items-center">
+        {tagNames.map((tagName) => (
+          <Link
+            to={`https://www.aipictors.com/search/?tag=${tagName}`}
+            key={tagName}
+          >
+            <Button variant={"link"}>{`#${tagName}`}</Button>
+          </Link>
+        ))}
+        {isEditable && (
+          <Button
+            onClick={() => {
+              setIsOpenEdit(!isOpenEdit)
+            }}
+            className="h-8 w-8"
+            size={"icon"}
+            variant={"ghost"}
+          >
+            <PlusIcon />
+          </Button>
+        )}
+      </div>
+      {isOpenEdit && (
+        <WorkTagInput
+          postId={postId}
+          tags={tags}
+          setTags={setTags}
+          isEditable={true}
+        />
       )}
-    </div>
+    </>
   )
 }

--- a/app/routes/($lang)._main.posts.$post/_components/work-article.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-article.tsx
@@ -153,6 +153,7 @@ export const WorkArticle = (props: Props) => {
             </div>
           )}
           <WorkArticleTags
+            postId={props.work.id}
             tagNames={props.work.tagNames}
             isEditable={props.work.isTagEditable}
           />

--- a/app/routes/($lang)._main.posts.$post/_components/work-tag-input.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-tag-input.tsx
@@ -8,7 +8,7 @@ type Props = {
   postId: string
   tags: Tag[]
   isEditable?: boolean
-  setTags: (tags: Tag[]) => void
+  setTags: React.Dispatch<React.SetStateAction<Tag[]>>
 }
 
 export const WorkTagInput = (props: Props) => {
@@ -34,9 +34,7 @@ export const WorkTagInput = (props: Props) => {
         placeholder="追加するタグを入力"
         tags={props.tags}
         className="sm:min-w-[450px]"
-        setTags={(newTags) => {
-          props.setTags(newTags as [Tag, ...Tag[]])
-        }}
+        setTags={props.setTags}
       />
       <Button
         className="w-full"

--- a/app/routes/($lang)._main.posts.$post/_components/work-tag-input.tsx
+++ b/app/routes/($lang)._main.posts.$post/_components/work-tag-input.tsx
@@ -1,0 +1,63 @@
+import { type Tag, TagInput } from "@/_components/tag/tag-input"
+import { Button } from "@/_components/ui/button"
+import { useMutation } from "@apollo/client/index"
+import { graphql } from "gql.tada"
+import { Loader2Icon } from "lucide-react"
+
+type Props = {
+  postId: string
+  tags: Tag[]
+  isEditable?: boolean
+  setTags: (tags: Tag[]) => void
+}
+
+export const WorkTagInput = (props: Props) => {
+  const [updateWorkTags, { loading: isUpdatingWorkTags }] = useMutation(
+    updateWorkTagsMutation,
+  )
+
+  const handleSave = async () => {
+    const tags = props.tags.map((tag) => tag.text)
+    await updateWorkTags({
+      variables: {
+        input: {
+          id: props.postId,
+          tags: tags,
+        },
+      },
+    })
+  }
+
+  return (
+    <div className="flex flex-col items-center space-y-2">
+      <TagInput
+        placeholder="追加するタグを入力"
+        tags={props.tags}
+        className="sm:min-w-[450px]"
+        setTags={(newTags) => {
+          props.setTags(newTags as [Tag, ...Tag[]])
+        }}
+      />
+      <Button
+        className="w-full"
+        onClick={handleSave}
+        size={"icon"}
+        variant={"secondary"}
+      >
+        {isUpdatingWorkTags ? (
+          <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          "保存"
+        )}
+      </Button>
+    </div>
+  )
+}
+
+const updateWorkTagsMutation = graphql(
+  `mutation UpdateWorkTags($input: UpdateWorkTagsInput!) {
+    updateWorkTags(input: $input) {
+      id
+    }
+  }`,
+)


### PR DESCRIPTION
・作品画面のタグ一覧の横にタグ追加ボタンを追加する
・タグの編集を行えるようにする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 記事に関連するタグの追加・編集機能を持つ`WorkTagInput`コンポーネントを導入しました。
  
- **改善**
  - `WorkArticleTags`コンポーネント内のタグ表示部分をリファクタリングし、編集モードの条件付きレンダリングを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->