### PR TITLE
トップページのクエリを統合する

### DIFF
--- a/app/routes/($lang)._main._index/_components/home-event-banner.tsx
+++ b/app/routes/($lang)._main._index/_components/home-event-banner.tsx
@@ -12,8 +12,11 @@ export const HomeEventBanner = () => {
           AI IDOLプロジェクトを応援してみよう！
         </p>
         <Link to="https://beta.aipictors.com/events/ai-idol-project">
-          {/* biome-ignore lint/a11y/useButtonType: <explanation> */}
-          <button className="m-auto mt-2 mb-2 w-32 rounded-full bg-blue-500 px-4 py-1 text-white">
+          {/** TODO_2024_07: Buttonに変更する */}
+          <button
+            type={"button"}
+            className="m-auto mt-2 mb-2 w-32 rounded-full bg-blue-500 px-4 py-1 text-white"
+          >
             詳細
           </button>
         </Link>

--- a/app/routes/($lang)._main._index/_components/home-generation-banner.tsx
+++ b/app/routes/($lang)._main._index/_components/home-generation-banner.tsx
@@ -20,8 +20,11 @@ export const HomeGenerationBanner = (props: Props) => {
           投稿できる！
         </p>
         <Link to="/generation">
-          {/* biome-ignore lint/a11y/useButtonType: <explanation> */}
-          <button className="mt-2 mb-2 w-full rounded-full bg-blue-500 px-4 py-1 text-white">
+          {/** TODO_2024_07: Buttonに変更する */}
+          <button
+            type={"button"}
+            className="mt-2 mb-2 w-full rounded-full bg-blue-500 px-4 py-1 text-white"
+          >
             生成
           </button>
         </Link>


### PR DESCRIPTION
トップページに必要なクエリを集めて統合した。これらのコンポーネントは内部のuseQueryを削除すればローディングが不要になる。

```tsx
<HomeWorksGeneratedSection
  // works={data.generationWorks}
/>
<HomeAwardWorkSection
  title={"前日ランキング"}
  // awardDateText={data.awardDateText}
  // works={data.workAwards.map((award) => award.work)}
/>
<HomeWorksUsersRecommendedSection
  // works={data.promotionWorks}
/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `HomeEventBanner`および`HomeGenerationBanner`コンポーネントのボタンに`type`属性を追加し、アクセシビリティとセマンティクスを向上。
  - `SensitivePage`コンポーネントに`ConstructionAlert`を追加し、開発中であることをユーザーに通知。

- **機能改善**
  - データ取得ロジックを改善し、クエリを統合して効率的にデータを取得。
  - タグの取得数を増やし、ユーザーに多様なタグを提供。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->