### PR TITLE
[fix] いいねボタンのエラーを修正する

### DIFF
--- a/app/_components/like-button.tsx
+++ b/app/_components/like-button.tsx
@@ -34,6 +34,55 @@ export const LikeButton = ({
   isParticle = false,
 }: LikeButtonProps) => {
   const authContext = useContext(AuthContext)
+  const [createWorkLike, { loading: isCreateLoading }] = useMutation(
+    createWorkLikeMutation,
+  )
+  const [deleteWorkLike, { loading: isDeleteLoading }] = useMutation(
+    deleteWorkLikeMutation,
+  )
+  const [isLiked, setIsLiked] = useState(defaultLiked)
+  const [likedCount, setLikedCount] = useState(defaultLikedCount)
+
+  useEffect(() => {
+    setIsLiked(defaultLiked)
+    setLikedCount(defaultLikedCount)
+  }, [defaultLiked, defaultLikedCount, targetWorkId])
+
+  const handleOnClick = async () => {
+    if (onClick) {
+      onClick(!isLiked)
+    }
+
+    try {
+      if (!isLiked) {
+        setLikedCount((prevCount) => prevCount + 1)
+        await createWorkLike({
+          variables: {
+            input: {
+              workId: targetWorkId,
+            },
+          },
+        })
+      } else {
+        setLikedCount((prevCount) => prevCount - 1)
+        await deleteWorkLike({
+          variables: {
+            input: {
+              workId: targetWorkId,
+            },
+          },
+        })
+      }
+      setIsLiked(!isLiked)
+    } catch (error) {
+      console.error("Error updating like status", error)
+    }
+  }
+
+  /* 自分自身の作品の場合はいいねボタンを表示しない */
+  if (authContext.userId === targetWorkOwnerUserId) {
+    return null
+  }
 
   /* 未ログイン */
   if (authContext.isLoading || authContext.isNotLoggedIn) {
@@ -88,59 +137,7 @@ export const LikeButton = ({
     )
   }
 
-  const [createWorkLike, { loading: isCreateLoading }] = useMutation(
-    createWorkLikeMutation,
-  )
-
-  const [deleteWorkLike, { loading: isDeleteLoading }] = useMutation(
-    deleteWorkLikeMutation,
-  )
-
   const width = Math.floor(size * 24)
-
-  const [isLiked, setIsLiked] = useState(defaultLiked)
-  const [likedCount, setLikedCount] = useState(defaultLikedCount)
-
-  useEffect(() => {
-    setIsLiked(defaultLiked)
-    setLikedCount(defaultLikedCount)
-  }, [targetWorkId])
-
-  const handleOnClick = async () => {
-    if (onClick) {
-      onClick(!isLiked)
-    }
-
-    try {
-      if (!isLiked) {
-        setLikedCount((prevCount) => prevCount + 1)
-        await createWorkLike({
-          variables: {
-            input: {
-              workId: targetWorkId,
-            },
-          },
-        })
-      } else {
-        setLikedCount((prevCount) => prevCount - 1)
-        await deleteWorkLike({
-          variables: {
-            input: {
-              workId: targetWorkId,
-            },
-          },
-        })
-      }
-      setIsLiked(!isLiked)
-    } catch (error) {
-      console.error("Error updating like status", error)
-    }
-  }
-
-  /* 自分自身の作品の場合はいいねボタンを表示しない */
-  if (authContext.userId === targetWorkOwnerUserId) {
-    return null
-  }
 
   return (
     <button


### PR DESCRIPTION
下記のエラーが出るので修正する。
このエラーは、LikeButtonコンポーネントのフックの順序がレンダリング間で異なっていることが原因と思われる。
下記を対応する。
・すべてのフック呼び出しをコンポーネントの最上部に移動して、条件分岐の前に配置します。
・ifブロックの中でフックを呼び出さないようにします。
```
like-button.tsx:91 Warning: React has detected a change in the order of Hooks called by LikeButton. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks

   Previous render            Next render
   ------------------------------------------------------
1. useContext                 useContext
2. undefined                  useContext
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    at LikeButton (http://localhost:5173/app/_components/like-button.tsx:11:3)
    at default
    at RenderedRoute (http://localhost:5173/node_modules/.vite/deps/@remix-run_react.js?v=2ff9a05a:857:5)
    at Outlet (http://localhost:5173/node_modules/.vite/deps/@remix-run_react.js?v=2ff9a05a:1191:26)
    at App
    at Suspense
    at Q (http://localhost:5173/node_modules/.vite/deps/react-photo-view.js?v=2ff9a05a:462:15)
    at AutoLoginProvider (http://localhost:5173/app/_components/auto-login-provider.tsx:12:8)
    at AuthContextProvider (http://localhost:5173/app/_components/auth-context-provider.tsx:10:40)
    at ApolloProvider (http://localhost:5173/node_modules/.vite/deps/@apollo_client_index.js?v=2ff9a05a:6237:19)
    at QueryClientProvider (http://localhost:5173/node_modules/.vite/deps/@tanstack_react-query.js?v=2ff9a05a:2695:3)
    at ContextProviders (http://localhost:5173/app/_components/context-providers.tsx:20:27)
    at O (http://localhost:5173/node_modules/.vite/deps/next-themes.js?v=2ff9a05a:23:25)
    at z (http://localhost:5173/node_modules/.vite/deps/next-themes.js?v=2ff9a05a:21:18)
```