### PR TITLE
fix: お題カレンダーの土日判定を修正

### DIFF
--- a/app/routes/($lang)._main.themes._index/components/theme-list.tsx
+++ b/app/routes/($lang)._main.themes._index/components/theme-list.tsx
@@ -32,7 +32,7 @@ export function ThemeList(props: Props) {
       day === currentDateInJapan.getDate()
 
     // 正しい曜日を算出
-    const dayOfWeek = (index + firstDayOfWeek) % 7
+    const dayOfWeek = day ? (day + firstDayOfWeek - 1) % 7 : null
 
     return {
       id: `/${props.year}-${props.month}-${index}`,


### PR DESCRIPTION
fix #683 
曜日の判定にindexではなくdayを使用するように変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - `ThemeList` 関数内の `dayOfWeek` 変数の計算方法を改善し、`day` が未定義の場合に適切に null を返すようにしました。これにより、意図しない結果を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->