### PR TITLE
和気あいAI3_参加者情報修正

### DIFF
--- a/app/routes/events.wakiaiai3/assets/event-users.ts
+++ b/app/routes/events.wakiaiai3/assets/event-users.ts
@@ -74,6 +74,18 @@ export const eventUsers: EventUser[] = [
     links: [],
   },
   {
+    name: "東海アニメ研究会「Zeele」",
+    types: ["SHOP", "EXHIBIT"],
+    message: null,
+    iconImageURL:
+      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiaiai3_TokaiAnime.jpg?alt=media&token=88e157d2-1432-470f-81aa-9fd6705d8688",
+    twitterId: "TokaiAnime",
+    aipictorsId: null,
+    siteURL: null,
+    siteTitle: null,
+    links: [],
+  },
+  {
     name: "晴レル屋",
     types: ["SHOP"],
     message: null,
@@ -301,18 +313,7 @@ export const eventUsers: EventUser[] = [
     siteTitle: null,
     links: [],
   },
-  {
-    name: "東海アニメ研究会「Zeele」",
-    types: ["EXHIBIT"],
-    message: null,
-    iconImageURL:
-      "https://firebasestorage.googleapis.com/v0/b/kwkjsui8ghyt93ai5feb.appspot.com/o/events%2Fwakiaiai%2Fwakiaiai3_TokaiAnime.jpg?alt=media&token=88e157d2-1432-470f-81aa-9fd6705d8688",
-    twitterId: "TokaiAnime",
-    aipictorsId: null,
-    siteURL: null,
-    siteTitle: null,
-    links: [],
-  },
+
   {
     name: "さつき＠うさぎ好き",
     types: ["EXHIBIT"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「東海アニメ研究会「Zeele」」の新しいエントリーがイベントユーザーに追加され、タイプが「SHOP」と「EXHIBIT」として表示されます。
- **変更点**
  - 以前の「東海アニメ研究会「Zeele」」のエントリーが「EXHIBIT」タイプから削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->