### PR TITLE
トップ画面のキャッシュを修正する

### DIFF
--- a/app/routes/($lang)._main._index/route.tsx
+++ b/app/routes/($lang)._main._index/route.tsx
@@ -33,7 +33,10 @@ const getUtcDateString = (date: Date) => {
 }
 
 export async function loader(props: LoaderFunctionArgs) {
-  const redirectResponse = checkLocaleRedirect(props.request)
+  const redirectResponse = checkLocaleRedirect(
+    props.request,
+    config.cacheControl.home,
+  )
 
   if (redirectResponse) {
     return redirectResponse

--- a/app/utils/check-locale-redirect.ts
+++ b/app/utils/check-locale-redirect.ts
@@ -1,7 +1,7 @@
 import { json } from "@remix-run/react"
 import { parse } from "cookie"
 
-export function checkLocaleRedirect(request: Request) {
+export function checkLocaleRedirect(request: Request, cacheControl?: string) {
   const cookieHeader = request.headers.get("Cookie")
   const cookies = cookieHeader ? parse(cookieHeader) : {}
 
@@ -15,15 +15,24 @@ export function checkLocaleRedirect(request: Request) {
   const url = new URL(request.url)
   const pathname = url.pathname
 
+  const headers: Record<string, string> = {
+    Vary: "Cookie, Accept-Language",
+  }
+
+  // cacheControl が指定されている場合、Cache-Control ヘッダーを追加
+  if (cacheControl) {
+    headers["Cache-Control"] = cacheControl
+  }
+
   // locale が "en" で URL が /en で始まっていない場合にリダイレクト
   if (locale === "en" && !pathname.startsWith("/en")) {
+    headers.Location = `/en${pathname}`
     return json(null, {
       status: 302,
-      headers: {
-        Location: `/en${pathname}`,
-      },
+      headers,
     })
   }
 
-  return null // リダイレクト不要の場合は null を返す
+  // リダイレクト不要の場合は null を返す
+  return null
 }


### PR DESCRIPTION
**リダイレクトのレスポンスに以下のヘッダーを設定することで、キャッシュの挙動を制御します。**

#### **a. Cache-Control ヘッダー**

- **キャッシュの有効期限や方針を指定**します。
- **例**：`Cache-Control: max-age=0, s-maxage=3600`（CDNで3600秒キャッシュ）

#### **b. Vary ヘッダー**

- **キャッシュがどのリクエストヘッダーに依存するかを指定**します。
- **Cookieに依存する場合**：`Vary: Cookie`
- **複数のヘッダーに依存する場合**：`Vary: Cookie, Accept-Language`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- リダイレクトロジックが改善され、キャッシュ制御設定が組み込まれました。

- **バグ修正**
	- なし

- **ドキュメント**
	- エクスポートされた関数のシグネチャが更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->