### PR TITLE
生成画面ではセンシティブのトグルボタンを非表示にする

### DIFF
--- a/app/routes/($lang)._main._index/components/home-header-not-logged-in-menu.tsx
+++ b/app/routes/($lang)._main._index/components/home-header-not-logged-in-menu.tsx
@@ -81,7 +81,7 @@ export const HomeHeaderNotLoggedInMenu = () => {
 
   const location = useLocation()
 
-  const shouldDisplayToggleSensitive = location.pathname !== "/generation"
+  const isSensitiveToggleVisible = location.pathname !== "/generation"
 
   const setLocale = (locale: string) => {
     // URLの先頭にある /ja または /en を正しく検出
@@ -182,7 +182,7 @@ export const HomeHeaderNotLoggedInMenu = () => {
             </DropdownMenuSubContent>
           </DropdownMenuPortal>
         </DropdownMenuSub>
-        {shouldDisplayToggleSensitive && (
+        {isSensitiveToggleVisible && (
           <DropdownMenuSub>
             <ToggleSensitive />
           </DropdownMenuSub>

--- a/app/routes/($lang)._main._index/components/home-header-not-logged-in-menu.tsx
+++ b/app/routes/($lang)._main._index/components/home-header-not-logged-in-menu.tsx
@@ -81,6 +81,8 @@ export const HomeHeaderNotLoggedInMenu = () => {
 
   const location = useLocation()
 
+  const shouldDisplayToggleSensitive = location.pathname !== "/generation"
+
   const setLocale = (locale: string) => {
     // URLの先頭にある /ja または /en を正しく検出
     const currentLocale = location.pathname.match(/^\/(ja|en)(\/|$)/)?.[1] || ""
@@ -180,9 +182,11 @@ export const HomeHeaderNotLoggedInMenu = () => {
             </DropdownMenuSubContent>
           </DropdownMenuPortal>
         </DropdownMenuSub>
-        <DropdownMenuSub>
-          <ToggleSensitive />
-        </DropdownMenuSub>
+        {shouldDisplayToggleSensitive && (
+          <DropdownMenuSub>
+            <ToggleSensitive />
+          </DropdownMenuSub>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/app/routes/($lang)._main._index/components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/components/home-user-navigation-menu.tsx
@@ -87,6 +87,8 @@ export function HomeUserNavigationMenu(props: Props) {
 
   const location = useLocation()
 
+  const shouldDisplayToggleSensitive = location.pathname !== "/generation"
+
   const setColorTheme = (newMode: string) => {
     if (newMode === "system") {
       setTheme(newMode)
@@ -309,7 +311,8 @@ export function HomeUserNavigationMenu(props: Props) {
           </DropdownMenuSub>
           {userSetting?.userSetting &&
             (userSetting?.userSetting.preferenceRating === "R18" ||
-              userSetting?.userSetting.preferenceRating === "R18G") && (
+              userSetting?.userSetting.preferenceRating === "R18G") &&
+            shouldDisplayToggleSensitive && (
               <DropdownMenuItem>
                 <ToggleSensitive />
               </DropdownMenuItem>

--- a/app/routes/($lang)._main._index/components/home-user-navigation-menu.tsx
+++ b/app/routes/($lang)._main._index/components/home-user-navigation-menu.tsx
@@ -87,7 +87,7 @@ export function HomeUserNavigationMenu(props: Props) {
 
   const location = useLocation()
 
-  const shouldDisplayToggleSensitive = location.pathname !== "/generation"
+  const isSensitiveToggleVisible = location.pathname !== "/generation"
 
   const setColorTheme = (newMode: string) => {
     if (newMode === "system") {
@@ -312,7 +312,7 @@ export function HomeUserNavigationMenu(props: Props) {
           {userSetting?.userSetting &&
             (userSetting?.userSetting.preferenceRating === "R18" ||
               userSetting?.userSetting.preferenceRating === "R18G") &&
-            shouldDisplayToggleSensitive && (
+            isSensitiveToggleVisible && (
               <DropdownMenuItem>
                 <ToggleSensitive />
               </DropdownMenuItem>


### PR DESCRIPTION
メニューのセンシティブモードの切り替えについて生成画面上では非表示にする。
理由は、ユーザにセンシティブモードをONにしたら、センシティブな画像を生成できると勘違いさせてしまっているため。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- `ToggleSensitive` コンポーネントの表示条件を追加し、特定のパスでのみ表示されるようにしました。
- **変更点**
	- `HomeHeaderNotLoggedInMenu` と `HomeUserNavigationMenu` における `ToggleSensitive` コンポーネントのレンダリングロジックを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->