### PR TITLE
ユーザ画面のコンポーネントを分割、単体テストを追加

### DIFF
--- a/app/routes/($lang)._main.users.$user._index/__tests__/handle-user-tab-navigation.test.ts
+++ b/app/routes/($lang)._main.users.$user._index/__tests__/handle-user-tab-navigation.test.ts
@@ -1,0 +1,88 @@
+import { handleUserTabNavigation } from "~/routes/($lang)._main.users.$user._index/utils/handle-user-tab-navigation"
+
+describe("handleUserTabNavigation", () => {
+
+  test("日本語のポートフォリオにナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "ポートフォリオ",
+      lang: "ja",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123")
+  })
+
+  test("英語のPortfolioにナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "Portfolio",
+      lang: "en",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123")
+  })
+
+  test("日本語の画像にナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "画像",
+      lang: "ja",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123/posts")
+  })
+
+  test("英語のImagesにナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "Images",
+      lang: "en",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123/posts")
+  })
+
+  test("日本語のスタンプにナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "スタンプ",
+      lang: "ja",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123/stickers")
+  })
+
+  test("英語のStickersにナビゲートする", () => {
+    const onNavigateCallback = jest.fn()
+    const props = {
+      userId: "123",
+      type: "Stickers",
+      lang: "en",
+      onNavigateCallback
+    }
+
+    handleUserTabNavigation(props)
+
+    expect(onNavigateCallback).toHaveBeenCalledWith("/users/123/stickers")
+  })
+})

--- a/app/routes/($lang)._main.users.$user._index/__tests__/use-user-active-tab.test.ts
+++ b/app/routes/($lang)._main.users.$user._index/__tests__/use-user-active-tab.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "bun:test"
+import { useUserActiveTab } from "~/routes/($lang)._main.users.$user._index/hooks/use-user-active-tab"
+
+describe("useUserActiveTab", () => {
+
+  test("日本語のポートフォリオをデフォルトで返す", () => {
+    const props = {
+      url: "/users/123",
+      lang: "ja",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("ポートフォリオ")
+  })
+
+  test("英語のPortfolioをデフォルトで返す", () => {
+    const props = {
+      url: "/users/123",
+      lang: "en",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("Portfolio")
+  })
+
+  test("日本語の画像を返す", () => {
+    const props = {
+      url: "/users/123/posts",
+      lang: "ja",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("画像")
+  })
+
+  test("英語のImagesを返す", () => {
+    const props = {
+      url: "/users/123/posts",
+      lang: "en",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("Images")
+  })
+
+  test("日本語の小説を返す", () => {
+    const props = {
+      url: "/users/123/novels",
+      lang: "ja",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("小説")
+  })
+
+  test("英語のNovelsを返す", () => {
+    const props = {
+      url: "/users/123/novels",
+      lang: "en",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("Novels")
+  })
+
+  test("日本語のスタンプを返す", () => {
+    const props = {
+      url: "/users/123/stickers",
+      lang: "ja",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("スタンプ")
+  })
+
+  test("英語のStickersを返す", () => {
+    const props = {
+      url: "/users/123/stickers",
+      lang: "en",
+    }
+
+    const getActiveTab = useUserActiveTab(props)
+
+    expect(getActiveTab()).toBe("Stickers")
+  })
+})

--- a/app/routes/($lang)._main.users.$user._index/__tests__/use-user-tab-label.test.ts
+++ b/app/routes/($lang)._main.users.$user._index/__tests__/use-user-tab-label.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from "bun:test"
+import { useUserTabLabels } from "~/routes/($lang)._main.users.$user._index/hooks/use-user-tab-label"
+
+describe("useUserTabLabels", () => {
+
+  test("日本語のラベルを正しく返す", () => {
+    const props = {
+      hasImageWorks: true,
+      hasNovelWorks: true,
+      hasColumnWorks: false,
+      hasVideoWorks: true,
+      hasAlbums: false,
+      hasFolders: true,
+      hasPublicStickers: true,
+      lang: "ja"
+    }
+
+    const labels = useUserTabLabels(props)
+
+    expect(labels).toEqual([
+      "ポートフォリオ",
+      "画像",
+      "小説",
+      "動画",
+      "コレクション",
+      "スタンプ"
+    ])
+  })
+
+  test("英語のラベルを正しく返す", () => {
+    const props = {
+      hasImageWorks: true,
+      hasNovelWorks: false,
+      hasColumnWorks: true,
+      hasVideoWorks: true,
+      hasAlbums: true,
+      hasFolders: false,
+      hasPublicStickers: false,
+      lang: "en"
+    }
+
+    const labels = useUserTabLabels(props)
+
+    expect(labels).toEqual([
+      "portfolio",
+      "Images",
+      "Columns",
+      "Videos",
+      "Series"
+    ])
+  })
+
+  test("全てのプロパティがfalseの場合はポートフォリオのみを返す", () => {
+    const props = {
+      hasImageWorks: false,
+      hasNovelWorks: false,
+      hasColumnWorks: false,
+      hasVideoWorks: false,
+      hasAlbums: false,
+      hasFolders: false,
+      hasPublicStickers: false,
+      lang: "ja"
+    }
+
+    const labels = useUserTabLabels(props)
+
+    expect(labels).toEqual([
+      "ポートフォリオ"
+    ])
+  })
+
+  test("全てのプロパティがtrueの場合はすべてのラベルを返す", () => {
+    const props = {
+      hasImageWorks: true,
+      hasNovelWorks: true,
+      hasColumnWorks: true,
+      hasVideoWorks: true,
+      hasAlbums: true,
+      hasFolders: true,
+      hasPublicStickers: true,
+      lang: "en"
+    }
+
+    const labels = useUserTabLabels(props)
+
+    expect(labels).toEqual([
+      "portfolio",
+      "Images",
+      "Novels",
+      "Columns",
+      "Videos",
+      "Series",
+      "Collections",
+      "Stickers"
+    ])
+  })
+})

--- a/app/routes/($lang)._main.users.$user._index/components/user-tabs.tsx
+++ b/app/routes/($lang)._main.users.$user._index/components/user-tabs.tsx
@@ -1,7 +1,10 @@
-import { useNavigate, useLocation } from "@remix-run/react"
+import { useLocation, useNavigate } from "@remix-run/react"
 import { graphql, readFragment, type FragmentOf } from "gql.tada"
 import { Button } from "~/components/ui/button"
-import { useTranslation } from "~/hooks/use-translation"
+import { useLocale } from "~/hooks/use-locale"
+import { useUserActiveTab } from "~/routes/($lang)._main.users.$user._index/hooks/use-user-active-tab"
+import { useUserTabLabels } from "~/routes/($lang)._main.users.$user._index/hooks/use-user-tab-label"
+import { handleUserTabNavigation } from "~/routes/($lang)._main.users.$user._index/utils/handle-user-tab-navigation"
 
 type Props = {
   user: FragmentOf<typeof UserTabsFragment>
@@ -10,90 +13,47 @@ type Props = {
 export function UserTabs(props: Props) {
   const user = readFragment(UserTabsFragment, props.user)
 
-  const t = useTranslation()
-
-  const navigate = useNavigate()
-
   const location = useLocation()
 
-  /**
-   * 現在のURLパスに基づいてアクティブなタブを判定
-   * デフォルトは「ポートフォリオ」
-   * TODO: pathnameを引数に持つカスタムHooksとして定義して単体テストを追加
-   */
-  const getActiveTab = () => {
-    if (location.pathname.endsWith("/posts")) return t("画像", "Images")
-    if (location.pathname.endsWith("/novels")) return t("小説", "Novels")
-    if (location.pathname.endsWith("/notes")) return t("コラム", "Columns")
-    if (location.pathname.endsWith("/videos")) return t("動画", "Videos")
-    if (location.pathname.endsWith("/albums")) return t("シリーズ", "Series")
-    if (location.pathname.endsWith("/collections"))
-      return t("コレクション", "Collections")
-    if (location.pathname.endsWith("/stickers")) return t("スタンプ", "Stamps")
-    return t("ポートフォリオ", "Portfolio")
-  }
+  const locale = useLocale()
 
-  /**
-   * TODO: パスを返す関数を定義して単体テストを追加
-   */
-  const handleTabClick = (value: string) => {
-    if (value === t("ポートフォリオ", "Portfolio")) {
-      navigate(`/users/${user.login}`)
-    }
-    if (value === t("画像", "Images")) {
-      navigate(`/users/${user.login}/posts`)
-    }
-    if (value === t("小説", "Novels")) {
-      navigate(`/users/${user.login}/novels`)
-    }
-    if (value === t("コラム", "Columns")) {
-      navigate(`/users/${user.login}/notes`)
-    }
-    if (value === t("動画", "Videos")) {
-      navigate(`/users/${user.login}/videos`)
-    }
-    if (value === t("シリーズ", "Series")) {
-      navigate(`/users/${user.login}/albums`)
-    }
-    if (value === t("コレクション", "Collections")) {
-      navigate(`/users/${user.login}/collections`)
-    }
-    if (value === t("スタンプ", "Stamps")) {
-      navigate(`/users/${user.login}/stickers`)
-    }
-  }
+  const getActiveTab = useUserActiveTab({
+    url: location.pathname,
+    lang: locale,
+  })
 
-  /**
-   * TODO: 配列を返す関数を定義して単体テストを追加
-   */
-  const tabLabels = [
-    t("ポートフォリオ", "Portfolio"),
-    ...(user.hasImageWorks ? [t("画像", "Images")] : []),
-    ...(user.hasNovelWorks ? [t("小説", "Novels")] : []),
-    ...(user.hasColumnWorks ? [t("コラム", "Columns")] : []),
-    ...(user.hasVideoWorks ? [t("動画", "Videos")] : []),
-    ...(user.hasAlbums ? [t("シリーズ", "Series")] : []),
-    ...(user.hasFolders ? [t("コレクション", "Collections")] : []),
-    ...(user.hasPublicStickers ? [t("スタンプ", "Stamps")] : []),
-  ]
-
-  /**
-   * TODO: 不要
-   */
-  const removeParentheses = (str: string) => {
-    return str.replace(/\(([^)]+)\)/, "")
-  }
+  const tabLabels = useUserTabLabels({
+    hasImageWorks: user.hasImageWorks,
+    hasNovelWorks: user.hasNovelWorks,
+    hasVideoWorks: user.hasVideoWorks,
+    hasColumnWorks: user.hasColumnWorks,
+    hasFolders: user.hasFolders,
+    hasAlbums: user.hasAlbums,
+    hasPublicStickers: user.hasPublicStickers,
+    lang: locale,
+  })
 
   const activeTab = getActiveTab()
+
+  const navigate = useNavigate()
 
   return (
     <div className="grid grid-cols-3 gap-2">
       {tabLabels.map((label) => (
         <Button
-          key={removeParentheses(label)}
-          onClick={() => handleTabClick(removeParentheses(label))}
+          key={label}
+          onClick={() => {
+            handleUserTabNavigation({
+              type: label,
+              userId: user.login,
+              lang: locale,
+              onNavigateCallback: (url: string) => {
+                navigate(url)
+              },
+            })
+          }}
           variant="secondary"
-          className={removeParentheses(label) === activeTab ? "opacity-50" : ""}
+          className={label === activeTab ? "opacity-50" : ""}
         >
           {label}
         </Button>
@@ -102,8 +62,8 @@ export function UserTabs(props: Props) {
   )
 }
 
-export const UserTabsFragment = graphql(
-  `fragment UserTabsFragment on UserNode {
+export const UserTabsFragment = graphql(`
+  fragment UserTabsFragment on UserNode {
     id
     login
     hasImageWorks
@@ -113,5 +73,5 @@ export const UserTabsFragment = graphql(
     hasFolders
     hasAlbums
     hasPublicStickers
-  }`,
-)
+  }
+`)

--- a/app/routes/($lang)._main.users.$user._index/hooks/use-user-active-tab.ts
+++ b/app/routes/($lang)._main.users.$user._index/hooks/use-user-active-tab.ts
@@ -1,0 +1,18 @@
+type Props = {
+    url: string
+    lang: string
+}
+
+export const useUserActiveTab = (props: Props) => {  
+    return () => {
+      if (props.url.endsWith("/posts")) return props.lang === "ja" ? "画像" : "Images"
+      if (props.url.endsWith("/novels")) return props.lang === "ja" ? "小説" : "Novels"
+      if (props.url.endsWith("/notes")) return props.lang === "ja" ? "コラム" : "Columns"
+      if (props.url.endsWith("/videos")) return props.lang === "ja" ? "動画" : "Videos"
+      if (props.url.endsWith("/albums")) return props.lang === "ja" ? "シリーズ" : "Series"
+      if (props.url.endsWith("/collections"))
+        return props.lang === "ja" ? "コレクション" : "Collections"
+      if (props.url.endsWith("/stickers")) return props.lang === "ja" ? "スタンプ" : "Stickers"
+      return props.lang === "ja" ? "ポートフォリオ" : "Portfolio"
+    };
+  }

--- a/app/routes/($lang)._main.users.$user._index/hooks/use-user-tab-label.ts
+++ b/app/routes/($lang)._main.users.$user._index/hooks/use-user-tab-label.ts
@@ -1,0 +1,26 @@
+type Props = {
+  hasImageWorks: boolean
+  hasNovelWorks: boolean
+  hasColumnWorks: boolean
+  hasVideoWorks: boolean
+  hasAlbums: boolean
+  hasFolders: boolean
+  hasPublicStickers: boolean
+  lang: string
+}
+
+export const useUserTabLabels = (props: Props) => {
+  const t = (jaText: string, enText: string) =>
+    props.lang === "ja" ? jaText : enText
+
+  return [
+    t("ポートフォリオ", "portfolio"),
+    ...(props.hasImageWorks ? [t("画像", "Images")] : []),
+    ...(props.hasNovelWorks ? [t("小説", "Novels")] : []),
+    ...(props.hasColumnWorks ? [t("コラム", "Columns")] : []),
+    ...(props.hasVideoWorks ? [t("動画", "Videos")] : []),
+    ...(props.hasAlbums ? [t("シリーズ", "Series")] : []),
+    ...(props.hasFolders ? [t("コレクション", "Collections")] : []),
+    ...(props.hasPublicStickers ? [t("スタンプ", "Stickers")] : []),
+  ]
+}

--- a/app/routes/($lang)._main.users.$user._index/utils/handle-user-tab-navigation.ts
+++ b/app/routes/($lang)._main.users.$user._index/utils/handle-user-tab-navigation.ts
@@ -1,0 +1,38 @@
+
+
+type Props = {
+  userId: string,
+  type: string
+  lang: string
+  onNavigateCallback: (url: string) => void
+}
+
+export const handleUserTabNavigation = (props: Props) => {
+  const t = (jaText: string, enText: string) =>
+    props.lang === "ja" ? jaText : enText
+
+  if (props.type === t("ポートフォリオ", "Portfolio")) {
+    props.onNavigateCallback(`/users/${props.userId}`)
+  }
+  if (props.type === t("画像", "Images")) {
+    props.onNavigateCallback(`/users/${props.userId}/posts`)
+  }
+  if (props.type === t("小説", "Novels")) {
+    props.onNavigateCallback(`/users/${props.userId}/novels`)
+  }
+  if (props.type === t("コラム", "Columns")) {
+    props.onNavigateCallback(`/users/${props.userId}/notes`)
+  }
+  if (props.type === t("動画", "Videos")) {
+    props.onNavigateCallback(`/users/${props.userId}/videos`)
+  }
+  if (props.type === t("シリーズ", "Series")) {
+    props.onNavigateCallback(`/users/${props.userId}/albums`)
+  }
+  if (props.type === t("コレクション", "Collections")) {
+    props.onNavigateCallback(`/users/${props.userId}/collections`)
+  }
+  if (props.type === t("スタンプ", "Stickers")) {
+    props.onNavigateCallback(`/users/${props.userId}/stickers`)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザーのタブナビゲーションを処理する新しいテストスイートを追加しました。
	- ユーザーアクティブタブを取得するカスタムフックのテストを導入しました。
	- ユーザータブラベルを取得するカスタムフックのテストを追加しました。
	- ユーザータブコンポーネントのロジックを簡素化しました。

- **バグ修正**
	- 特定の言語設定に基づくタブラベルの取得ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->