### PR TITLE
投稿画面でイベントの項目が正しく表示されない不具合を修正

### DIFF
--- a/app/routes/($lang)._main.new.image/components/post-form-item-event.tsx
+++ b/app/routes/($lang)._main.new.image/components/post-form-item-event.tsx
@@ -20,7 +20,11 @@ type Props = {
  * イベント入力
  */
 export function PostFormItemEvent(props: Props) {
-  if (props.endAt > getJstDate().getTime() / 1000) {
+  const now = getJstDate(new Date())
+
+  const isOngoing = now <= new Date(props.endAt * 1000)
+
+  if (!isOngoing) {
     return null
   }
 


### PR DESCRIPTION
投稿画面でイベントの項目が正しく表示されないことがあるので修正する