### PR TITLE
タグページにメタ情報を追加する

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -474,6 +474,14 @@ export const META: { [key: string]: MetaData } = {
     enDescription: "Read the terms of use for Aipictors.",
     isIndex: true,
   },
+  TAGS: {
+    title: "{{title}}",
+    enTitle: "{{enTitle}}",
+    description: "{{description}}",
+    enDescription: "{{enDescription}}",
+    image: "{{url}}",
+    isIndex: true,
+  },
   USERS: {
     title: "{{title}}",
     enTitle: "{{enTitle}}",

--- a/app/routes/($lang)._main.tags.$tag._index/route.tsx
+++ b/app/routes/($lang)._main.tags.$tag._index/route.tsx
@@ -1,15 +1,20 @@
 import { ParamsError } from "~/errors/params-error"
 import { loaderClient } from "~/lib/loader-client"
 import { TagWorkSection } from "~/routes/($lang)._main.tags._index/components/tag-work-section"
-import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/cloudflare"
+import type {
+  HeadersFunction,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from "@remix-run/cloudflare"
 import { useParams, useSearchParams } from "@remix-run/react"
 import { useLoaderData } from "@remix-run/react"
-import { graphql } from "gql.tada"
+import { graphql, readFragment } from "gql.tada"
 import { PhotoAlbumWorkFragment } from "~/components/responsive-photo-works-album"
 import React, { useEffect } from "react"
 import type { IntrospectionEnum } from "~/lib/introspection-enum"
 import type { SortType } from "~/types/sort-type"
-import { config } from "~/config"
+import { config, META } from "~/config"
+import { createMeta } from "~/utils/create-meta"
 
 export async function loader(props: LoaderFunctionArgs) {
   if (props.params.tag === undefined) {
@@ -75,6 +80,32 @@ export async function loader(props: LoaderFunctionArgs) {
 export const headers: HeadersFunction = () => ({
   "Cache-Control": config.cacheControl.oneHour,
 })
+
+export const meta: MetaFunction<typeof loader> = (props) => {
+  if (!props.data) {
+    return [{ title: "タグページ" }]
+  }
+
+  const works = readFragment(PhotoAlbumWorkFragment, props.data.works)
+
+  const thumbnailUrl = works.length ? works[0].smallThumbnailImageURL : ""
+
+  const worksCount = props.data.worksCount
+
+  const tag = decodeURIComponent(props.params.tag ?? "")
+
+  return createMeta(
+    META.TAGS,
+    {
+      title: `${tag}のAIイラスト ${worksCount}件`,
+      enTitle: `A list of works where AI illustrations of ${tag} are posted.`,
+      description: `${tag}のAIイラストが投稿された作品一覧ページです。`,
+      enDescription: `This is a list of works where AI illustrations of ${tag} are posted.`,
+      url: thumbnailUrl,
+    },
+    props.params.lang,
+  )
+}
 
 export default function Tag() {
   const params = useParams()

--- a/app/routes/($lang)._main.tags._index/components/sensitive-tag-confirm-dialog.tsx
+++ b/app/routes/($lang)._main.tags._index/components/sensitive-tag-confirm-dialog.tsx
@@ -15,13 +15,20 @@ import { Button } from "~/components/ui/button"
 import { useNavigate } from "react-router-dom"
 import { RefreshCcwIcon } from "lucide-react"
 
-export function SensitiveTagConfirmDialog() {
+type Props = {
+  tag: string
+}
+
+export function SensitiveTagConfirmDialog(props: Props) {
   const t = useTranslation()
+
   const navigate = useNavigate()
+
   const [isOpen, setIsOpen] = useState(false)
+
   const [shouldSkipDialog, setShouldSkipDialog] = useState(false)
+
   const cookieKey = "check-sensitive-ranking"
-  const tag = "exampleTag" // 必要なタグ情報を直接ここで指定
 
   useEffect(() => {
     const cookieExists = document.cookie
@@ -31,7 +38,7 @@ export function SensitiveTagConfirmDialog() {
   }, [cookieKey])
 
   const handleNext = () => {
-    navigate(`/r/tags/${tag}`)
+    navigate(`/r/tags/${props.tag}`)
     setIsOpen(false)
   }
 

--- a/app/routes/($lang)._main.tags._index/components/tag-action-other.tsx
+++ b/app/routes/($lang)._main.tags._index/components/tag-action-other.tsx
@@ -26,7 +26,7 @@ export function TagActionOther(props: Props) {
       </PopoverTrigger>
       <PopoverContent className="w-80">
         <div className="relative grid gap-4">
-          <SensitiveTagConfirmDialog />
+          <SensitiveTagConfirmDialog tag={props.tag} />
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- タグに関連するメタデータを構成するための新しい設定が追加され、SEOとユーザー体験が向上しました。
	- `SensitiveTagConfirmDialog`コンポーネントが動的にタグ値を受け取るようになり、柔軟性が向上しました。

- **バグ修正**
	- なし

- **ドキュメント**
	- なし

- **リファクタリング**
	- コンポーネント間のデータフローが改善され、`tag`プロパティが適切に渡されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->