### PR TITLE
すべてのキャッシュ時間を1分にする、Assetsを同じファイル名で上書きする

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -6,7 +6,7 @@ import { env } from "~/env"
 export const config = {
   cacheControl: {
     get home() {
-      return "max-age=0, s-maxage=240, stale-while-revalidate=2592000, stale-if-error=2592000"
+      return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
     get short() {
       return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
@@ -18,16 +18,16 @@ export const config = {
       return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
     get oneHour() {
-      return "max-age=0, s-maxage=3600, stale-while-revalidate=2592000, stale-if-error=2592000"
+      return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
     get oneDay() {
-      return "max-age=0, s-maxage=86400, stale-while-revalidate=2592000, stale-if-error=2592000"
+      return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
     get oneWeek() {
-      return "max-age=0, s-maxage=604800, stale-while-revalidate=2592000, stale-if-error=2592000"
+      return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
     get oneMonth() {
-      return "max-age=0, s-maxage=2592000, stale-while-revalidate=2592000, stale-if-error=2592000"
+      return "max-age=0, s-maxage=60, stale-while-revalidate=2592000, stale-if-error=2592000"
     },
   },
   fcm: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,4 +57,13 @@ export default defineConfig({
   define: {
     VITE_VERSION: JSON.stringify(process.env.npm_package_version),
   },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: "assets/[name].js",
+        chunkFileNames: "assets/[name].js",
+        assetFileNames: "assets/[name].[ext]",
+      },
+    },
+  },
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - キャッシュ制御設定が標準化され、特定のエンドポイントのキャッシュ期間が60秒に変更されました。
  
- **ドキュメント**
  - ビルド設定に新しいセクションが追加され、出力ファイルの命名規則が定義されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->