### PR TITLE
Refactor comments and adjust import order in tailwind.css

### DIFF
--- a/app/routes/($lang)._main.new.image/components/post-form-item-draggable-images-and-video.tsx
+++ b/app/routes/($lang)._main.new.image/components/post-form-item-draggable-images-and-video.tsx
@@ -277,7 +277,6 @@ export function PostFormItemDraggableImagesAndVideo(props: Props) {
       >
         {!props.isOnlyMove && <input id="images_input" {...getInputProps()} />}
         {props.items.length === 0 && !props.isOnlyMove && (
-          // biome-ignore lint/complexity/noUselessFragments: <explanation>
           <>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
             <div

--- a/app/routes/($lang)._main.new.image/components/post-form-item-draggable-images.tsx
+++ b/app/routes/($lang)._main.new.image/components/post-form-item-draggable-images.tsx
@@ -290,7 +290,6 @@ export function PostFormItemDraggableImages(props: Props) {
       >
         {!props.isOnlyMove && <input id="images_input" {...getInputProps()} />}
         {props.items.length === 0 && !props.isOnlyMove && (
-          // biome-ignore lint/complexity/noUselessFragments: <explanation>
           <>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
             <div

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
+@import "./theme.css";
 @plugin "@tailwindcss/typography";
 @plugin 'tailwindcss-animate';
-@import "./theme.css";
 
 :root {
   --background: hsl(0 0% 100%);


### PR DESCRIPTION
Remove unnecessary biome-ignore comments and reorder imports in tailwind.css for improved clarity and organization.