### PR TITLE
feat: スタンプ一覧のコンポーネントにて@_unmaskを廃止する

### DIFF
--- a/app/components/responsive-stickers-list.tsx
+++ b/app/components/responsive-stickers-list.tsx
@@ -1,57 +1,60 @@
 import { Link } from "@remix-run/react"
-import { graphql, type FragmentOf } from "gql.tada"
+import { graphql, readFragment, type FragmentOf } from "gql.tada"
 import { Download, MessageCircle } from "lucide-react"
 
 type Props = {
   stickers: FragmentOf<typeof StickerListItemFragment>[]
-  targetRowHeight?: number
 }
 
 /**
  * レスポンシブ対応のスタンプ一覧
  */
 export function ResponsiveStickersList(props: Props) {
-  if (props.stickers === null || props.stickers.length === 0) {
+  if (!props.stickers || props.stickers.length === 0) {
     return null
   }
 
   return (
     <div className="flex flex-wrap">
-      {props.stickers.map((sticker) => (
-        <div key={sticker.id} className="m-2 overflow-hidden rounded-md">
-          <Link
-            to={`/stickers/${sticker.id}`}
-            className="group relative block p-1"
-          >
-            <div className="overflow-hidden rounded-md">
-              <img
-                className="m-auto max-w-32 rounded-md transition-transform duration-200 ease-in-out group-hover:scale-105"
-                src={sticker.imageUrl ?? ""}
-                alt={sticker.title}
-              />
-            </div>
-            <div className="h-24 max-w-32 space-y-2 overflow-hidden rounded-md">
-              <span className="text-ellipsis text-nowrap text-sm">
-                {sticker.title}
-              </span>
-              <div className="flex items-center">
-                <Download size={16} />
-                <span>{sticker.downloadsCount}</span>
+      {props.stickers.map((stickerRef) => {
+        const sticker = readFragment(StickerListItemFragment, stickerRef)
+
+        return (
+          <div key={sticker.id} className="m-2 overflow-hidden rounded-md">
+            <Link
+              to={`/stickers/${sticker.id}`}
+              className="group relative block p-1"
+            >
+              <div className="overflow-hidden rounded-md">
+                <img
+                  className="m-auto max-w-32 rounded-md transition-transform duration-200 ease-in-out group-hover:scale-105"
+                  src={sticker.imageUrl ?? ""}
+                  alt={sticker.title}
+                />
               </div>
-              <div className="flex items-center">
-                <MessageCircle size={16} />
-                <span>{sticker.usesCount}</span>
+              <div className="h-24 max-w-32 space-y-2 overflow-hidden rounded-md">
+                <span className="text-ellipsis whitespace-nowrap text-sm">
+                  {sticker.title}
+                </span>
+                <div className="flex items-center">
+                  <Download size={16} />
+                  <span>{sticker.downloadsCount.toLocaleString()}</span>
+                </div>
+                <div className="flex items-center">
+                  <MessageCircle size={16} />
+                  <span>{sticker.usesCount.toLocaleString()}</span>
+                </div>
               </div>
-            </div>
-          </Link>
-        </div>
-      ))}
+            </Link>
+          </div>
+        )
+      })}
     </div>
   )
 }
 
 export const StickerListItemFragment = graphql(
-  `fragment StickerListItem on StickerNode @_unmask {
+  `fragment StickerListItem on StickerNode {
     id
     title
     downloadsCount


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 対応issue
-

## プルリクの内容
<!-- このプルリクでやったこと、参考リンク、画面イメージなど -->
- _unmaskを廃止してFragmentを経由しないと値を読み取れないようにする

<!-- 生成AIにコードを書いてもらった場合、利用したプロンプトを記載する -->
<details><summary>使用したプロンプト</summary>

### LLM
Claude 3.7 Sonnet

### プロンプト
```markdown
```
</details>

## 動作確認
- CI
- [スタンプ広場](http://localhost:5173/stickers)にて一覧が正常に表示されること
![image](https://github.com/user-attachments/assets/c818f482-6056-4c3a-87ad-af5f793a5ab6)
