### PR TITLE
refactor: 動画一覧コンポーネントの@_unmaskを廃止する

### DIFF
--- a/app/components/responsive-photo-video-works-album.tsx
+++ b/app/components/responsive-photo-video-works-album.tsx
@@ -30,7 +30,7 @@ export function ResponsivePhotoVideoWorksAlbum(props: Props) {
   const { data: videosWorks } = useQuery(UserVideosQuery, {
     skip: authContext.isLoading || authContext.isNotLoggedIn,
     variables: {
-      offset: props.page ?? 1 * 32,
+      offset: (props.page ?? 1) * 32,
       limit: 32,
       where: {
         userId: cachedWorks[0]?.user?.id ?? "",

--- a/app/routes/($lang)._main.users.$user.videos/route.tsx
+++ b/app/routes/($lang)._main.users.$user.videos/route.tsx
@@ -4,11 +4,9 @@ import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/cloudflare"
 import { useParams } from "@remix-run/react"
 import { useLoaderData } from "@remix-run/react"
 import { graphql } from "gql.tada"
-import {
-  UserVideoList,
-  UserVideosItemFragment,
-} from "~/routes/($lang)._main.users.$user.videos/components/user-videos-list"
+import { UserVideoList } from "~/routes/($lang)._main.users.$user.videos/components/user-videos-list"
 import { config } from "~/config"
+import { PhotoAlbumVideoWorkFragment } from "~/components/responsive-photo-video-works-album"
 
 export async function loader(props: LoaderFunctionArgs) {
   if (props.params.user === undefined) {
@@ -90,9 +88,9 @@ const userIdQuery = graphql(
 export const userVideosQuery = graphql(
   `query UserWorks($offset: Int!, $limit: Int!, $where: WorksWhereInput) {
     works(offset: $offset, limit: $limit, where: $where) {
-      ...UserVideosItem
+      ...PhotoAlbumVideoWork
     }
     worksCount(where: $where)
   }`,
-  [UserVideosItemFragment],
+  [PhotoAlbumVideoWorkFragment],
 )

--- a/app/routes/($lang).r.users.$user.videos/components/user-sensitive-videos-list.tsx
+++ b/app/routes/($lang).r.users.$user.videos/components/user-sensitive-videos-list.tsx
@@ -1,13 +1,16 @@
-import { type FragmentOf, graphql } from "gql.tada"
+import { type FragmentOf, graphql, readFragment } from "gql.tada"
 import { AuthContext } from "~/contexts/auth-context"
 import { useQuery } from "@apollo/client/index"
 import { useContext } from "react"
 import { useNavigate } from "react-router-dom"
 import { ResponsivePagination } from "~/components/responsive-pagination"
-import { ResponsivePhotoVideoWorksAlbum } from "~/components/responsive-photo-video-works-album"
+import {
+  PhotoAlbumVideoWorkFragment,
+  ResponsivePhotoVideoWorksAlbum,
+} from "~/components/responsive-photo-video-works-album"
 
 type Props = {
-  works: FragmentOf<typeof UserVideosItemFragment>[]
+  works: FragmentOf<typeof PhotoAlbumVideoWorkFragment>[]
   page: number
   maxCount: number
 }
@@ -15,9 +18,11 @@ type Props = {
 export function UserSensitiveVideoList(props: Props) {
   const authContext = useContext(AuthContext)
 
-  const userId = props.works[0]?.user?.id ?? ""
+  const cachedWorks = readFragment(PhotoAlbumVideoWorkFragment, props.works)
 
-  const userLogin = props.works[0]?.user?.login ?? ""
+  const userId = cachedWorks[0]?.user?.id ?? ""
+
+  const userLogin = cachedWorks[0]?.user?.login ?? ""
 
   const { data: videosWorks } = useQuery(UserVideosQuery, {
     skip: authContext.isLoading || authContext.isNotLoggedIn || userId === "",
@@ -44,6 +49,7 @@ export function UserSensitiveVideoList(props: Props) {
           <ResponsivePhotoVideoWorksAlbum
             isAutoPlay={true}
             works={props.works}
+            page={props.page}
           />
         </section>
       </div>
@@ -88,5 +94,5 @@ export const UserVideosQuery = graphql(
     }
     worksCount(where: $where)
   }`,
-  [UserVideosItemFragment],
+  [PhotoAlbumVideoWorkFragment],
 )

--- a/app/routes/($lang).r.users.$user.videos/route.tsx
+++ b/app/routes/($lang).r.users.$user.videos/route.tsx
@@ -4,9 +4,9 @@ import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/cloudflare"
 import { useParams } from "@remix-run/react"
 import { useLoaderData } from "@remix-run/react"
 import { graphql } from "gql.tada"
-import { UserVideosItemFragment } from "~/routes/($lang)._main.users.$user.videos/components/user-videos-list"
 import { UserSensitiveVideoList } from "~/routes/($lang).r.users.$user.videos/components/user-sensitive-videos-list"
 import { config } from "~/config"
+import { PhotoAlbumVideoWorkFragment } from "~/components/responsive-photo-video-works-album"
 
 export async function loader(props: LoaderFunctionArgs) {
   if (props.params.user === undefined) {
@@ -88,9 +88,9 @@ const userIdQuery = graphql(
 export const userVideosQuery = graphql(
   `query UserWorks($offset: Int!, $limit: Int!, $where: WorksWhereInput) {
     works(offset: $offset, limit: $limit, where: $where) {
-      ...UserVideosItem
+      ...PhotoAlbumVideoWork
     }
     worksCount(where: $where)
   }`,
-  [UserVideosItemFragment],
+  [PhotoAlbumVideoWorkFragment],
 )


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 対応issue
https://github.com/aipictors/aipictors/issues/938

## プルリクの内容
<!-- このプルリクでやったこと、参考リンク、画面イメージなど -->
- コンポーネント間のフラグメントの横取りを改善します。
- 下記のように、readFragmentを使用してデータを読み取ります。
```typescript
const cachedWorks = readFragment(PhotoAlbumVideoWorkFragment, props.works)
```
unmaskを廃止します。
```typescript
export const PhotoAlbumVideoWorkFragment = graphql(
  `fragment PhotoAlbumVideoWork on WorkNode {
```

<!-- 生成AIにコードを書いてもらった場合、利用したプロンプトを記載する -->
<details><summary>使用したプロンプト</summary>

### LLM
Claude 3.7 Sonnet

### プロンプト
```markdown
```
</details>

## 動作確認
- CI
- 動画一覧が正常に表示されること
![image](https://github.com/user-attachments/assets/4ca72370-9bde-4d02-aeca-6d4318fb0e7e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 動画作品アルバムの表示で、ユーザー認証やページ指定による動画作品の取得・切替が可能になりました。

- **改善**
  - 動画作品リストやセンシティブ動画リストのデータ取得・表示方法が統一され、安定性が向上しました。
  - 作品情報に評価やユーザー名が追加され、より詳細な情報が表示されます。

- **バグ修正**
  - 一部コンポーネントでのデータ取得・表示の不整合を解消しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->