### PR TITLE
feat: 画像の切り替えについてうまくいかない不具合を修正

### DIFF
--- a/app/components/images-preview.tsx
+++ b/app/components/images-preview.tsx
@@ -44,10 +44,7 @@ export function ImagesPreview(props: Props) {
       activeElement?.getAttribute("role") === "textbox"
 
     // モードに応じて対応するキーを決定
-    const supportedKeys =
-      mode === "dialog"
-        ? ["a", "d"] // ダイアログモードはADキーのみ
-        : ["ArrowLeft", "ArrowRight", "a", "d"] // ページモードは矢印キー + ADキー
+    const supportedKeys = ["arrowleft", "arrowright", "a", "d"]
 
     if (!isOpen) {
       if (supportedKeys.includes(e.key.toLowerCase()) && !isInputFocused) {
@@ -63,9 +60,8 @@ export function ImagesPreview(props: Props) {
     }
 
     if (
-      ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "a", "d"].includes(
-        e.key.toLowerCase(),
-      )
+      ["a", "d"].includes(e.key.toLowerCase()) ||
+      ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
     ) {
       e.preventDefault()
     }
@@ -73,13 +69,8 @@ export function ImagesPreview(props: Props) {
     if (e.key === "Escape") closePreview()
 
     // ダイアログモードの場合はADキーのみ、ページモードは矢印キー + ADキー
-    if (mode === "dialog") {
-      if (e.key.toLowerCase() === "a") prevImage()
-      if (e.key.toLowerCase() === "d") nextImage()
-    } else {
-      if (e.key === "ArrowLeft" || e.key.toLowerCase() === "a") prevImage()
-      if (e.key === "ArrowRight" || e.key.toLowerCase() === "d") nextImage()
-    }
+    if (e.key === "ArrowLeft" || e.key.toLowerCase() === "a") prevImage()
+    if (e.key === "ArrowRight" || e.key.toLowerCase() === "d") nextImage()
 
     if (e.key === "ArrowUp") increaseScale()
     if (e.key === "ArrowDown") decreaseScale()
@@ -361,37 +352,21 @@ export function ImagesPreview(props: Props) {
           <div className="absolute top-3 left-3 hidden items-center gap-2 rounded-lg bg-black/60 px-3 py-2 text-white backdrop-blur-sm md:flex">
             <Keyboard className="h-4 w-4" />
             <div className="flex items-center gap-1 text-xs">
-              {mode === "dialog" ? (
-                // ダイアログモード: ADキーのみ
-                <>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    A
-                  </kbd>
-                  <span className="mx-1">•</span>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    D
-                  </kbd>
-                </>
-              ) : (
-                // ページモード: ADキー + 矢印キー
-                <>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    A
-                  </kbd>
-                  <span>/</span>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    ←
-                  </kbd>
-                  <span className="mx-1">•</span>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    D
-                  </kbd>
-                  <span>/</span>
-                  <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
-                    →
-                  </kbd>
-                </>
-              )}
+              <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
+                A
+              </kbd>
+              <span>/</span>
+              <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
+                ←
+              </kbd>
+              <span className="mx-1">•</span>
+              <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
+                D
+              </kbd>
+              <span>/</span>
+              <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs">
+                →
+              </kbd>
             </div>
           </div>
         )}

--- a/app/components/work/work-viewer-dialog.tsx
+++ b/app/components/work/work-viewer-dialog.tsx
@@ -261,8 +261,8 @@ export function WorkViewerDialog({
         return
       }
 
-      if (e.key === "ArrowLeft") prev()
-      if (e.key === "ArrowRight") next()
+      if (e.key === "ArrowUp") prev()
+      if (e.key === "ArrowDown") next()
       if (e.key === "Escape") onClose()
     }
 

--- a/app/routes/($lang)._main.posts.$post._index/components/work-image-view.tsx
+++ b/app/routes/($lang)._main.posts.$post._index/components/work-image-view.tsx
@@ -26,48 +26,6 @@ export function WorkImageView(props: Props) {
     }
   }
 
-  // 左右キーでの画像切り替え（ダイアログモード以外）
-  useEffect(() => {
-    // ダイアログモードの場合は左右キー操作を無効にする
-    if (props.mode === "dialog" || !shouldRenderCarousel) {
-      return
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "ArrowLeft") {
-        event.preventDefault()
-        const newIndex =
-          currentIndex > 0 ? currentIndex - 1 : allImageURLs.length - 1
-        setCurrentIndex(newIndex)
-        if (props.onSelectedImage) {
-          props.onSelectedImage(allImageURLs[newIndex])
-        }
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault()
-        const newIndex =
-          currentIndex < allImageURLs.length - 1 ? currentIndex + 1 : 0
-        setCurrentIndex(newIndex)
-        if (props.onSelectedImage) {
-          props.onSelectedImage(allImageURLs[newIndex])
-        }
-      }
-    }
-
-    // イベントリスナーを追加
-    window.addEventListener("keydown", handleKeyDown)
-
-    // クリーンアップでイベントリスナーを削除
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown)
-    }
-  }, [
-    currentIndex,
-    allImageURLs,
-    shouldRenderCarousel,
-    props.mode,
-    props.onSelectedImage,
-  ])
-
   useEffect(() => {
     setCurrentIndex(0)
   }, [props.workImageURL])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 画像プレビューのキーボード操作が統一され、常に「A」「D」「←」「→」キーで画像の切り替えが可能になりました。
  * キーボードショートカットの表示も一貫した内容に変更されました。

* **変更**
  * ワークビューダイアログでのナビゲーションキーが「←」「→」から「↑」「↓」に変更されました。
  * 通常ページでの画像切り替え用キーボード操作（←/→キー）が削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->