### PR TITLE
Remove commented event banner label

### DIFF
--- a/app/routes/($lang)._main._index/components/home-banners.tsx
+++ b/app/routes/($lang)._main._index/components/home-banners.tsx
@@ -85,7 +85,6 @@ export function HomeBanners(props: Props) {
   return (
     <Carousel opts={{ dragFree: true, loop: true, align: "start" }}>
       <CarouselContent className="flex gap-x-4">
-        {/* イベントバナー */}
         {props.ongoingEvents?.map((event) => (
           <CarouselItem
             key={`event-${event.id}`}


### PR DESCRIPTION
Deleted an unused comment labeling the event banner section in the HomeBanners component for cleaner code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部コメント行を削除しました。ユーザー向けの機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->